### PR TITLE
Support simple asynchronous operations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: mymindstorm/setup-emsdk@v10
       with:
-        version: '3.0.0'
+        version: '3.1.13'
         # no-cache: true
         actions-cache-folder: 'emsdk-cache'
     - uses: actions/setup-node@v2

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -57,7 +57,7 @@
     },
     {
       "name": "Win32 Emscripten",
-      "defines": ["${defines}", "__wasm32__"],
+      "defines": ["${defines}", "__wasm32__", "__EMSCRIPTEN_PTHREADS__"],
       "compilerPath": "${env:EMSDK}\\upstream\\emscripten\\emcc.bat",
       "intelliSenseMode": "clang-x86",
       "cStandard": "c99",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
       "request": "launch",
       "name": "Launch Program",
       "runtimeArgs": ["--expose-gc"],
-      "program": "${workspaceFolder}/packages/test/emnapi/emnapi.test.js",
+      "program": "${workspaceFolder}/packages/test/async/async.test.js",
       "args": []
     },
     {

--- a/packages/emnapi/README.md
+++ b/packages/emnapi/README.md
@@ -4,9 +4,11 @@
 
 [Node-API (version 8)](https://nodejs.org/docs/v16.15.0/api/n-api.html) implementation for [Emscripten](https://emscripten.org/index.html), based on Node.js v16.15.0.
 
-[中文 README](https://github.com/toyobayashi/emnapi/tree/main/README_CN.md).
+[中文 README](https://github.com/toyobayashi/emnapi/tree/main/packages/emnapi/README_CN.md).
 
-[See documentation for more details](https://emnapi-docs.vercel.app/)
+[See documentation for more details](https://emnapi-docs.vercel.app/guide/)
+
+[Full API List](https://emnapi-docs.vercel.app/reference/list.html)
 
 ## Quick Start
 

--- a/packages/emnapi/README_CN.md
+++ b/packages/emnapi/README_CN.md
@@ -4,7 +4,9 @@
 
 适用于 [Emscripten](https://emscripten.org/index.html) 的 [Node-API (version 8)](https://nodejs.org/dist/latest-v16.x/docs/api/n-api.html) 实现，基于 Node.js v16.15.0
 
-[查看文档](https://emnapi-docs.vercel.app/)
+[查看文档](https://emnapi-docs.vercel.app/zh/guide/)
+
+[完整的 API 列表](https://emnapi-docs.vercel.app/zh/reference/list.html)
 
 ## 快速开始
 

--- a/packages/emnapi/include/napi-inl.h
+++ b/packages/emnapi/include/napi-inl.h
@@ -4759,212 +4759,212 @@ inline Value EscapableHandleScope::Escape(napi_value escapee) {
 // // AsyncWorker class
 // ////////////////////////////////////////////////////////////////////////////////
 
-// inline AsyncWorker::AsyncWorker(const Function& callback)
-//   : AsyncWorker(callback, "generic") {
-// }
+inline AsyncWorker::AsyncWorker(const Function& callback)
+  : AsyncWorker(callback, "generic") {
+}
 
-// inline AsyncWorker::AsyncWorker(const Function& callback,
-//                                 const char* resource_name)
-//   : AsyncWorker(callback, resource_name, Object::New(callback.Env())) {
-// }
+inline AsyncWorker::AsyncWorker(const Function& callback,
+                                const char* resource_name)
+  : AsyncWorker(callback, resource_name, Object::New(callback.Env())) {
+}
 
-// inline AsyncWorker::AsyncWorker(const Function& callback,
-//                                 const char* resource_name,
-//                                 const Object& resource)
-//   : AsyncWorker(Object::New(callback.Env()),
-//                 callback,
-//                 resource_name,
-//                 resource) {
-// }
+inline AsyncWorker::AsyncWorker(const Function& callback,
+                                const char* resource_name,
+                                const Object& resource)
+  : AsyncWorker(Object::New(callback.Env()),
+                callback,
+                resource_name,
+                resource) {
+}
 
-// inline AsyncWorker::AsyncWorker(const Object& receiver,
-//                                 const Function& callback)
-//   : AsyncWorker(receiver, callback, "generic") {
-// }
+inline AsyncWorker::AsyncWorker(const Object& receiver,
+                                const Function& callback)
+  : AsyncWorker(receiver, callback, "generic") {
+}
 
-// inline AsyncWorker::AsyncWorker(const Object& receiver,
-//                                 const Function& callback,
-//                                 const char* resource_name)
-//   : AsyncWorker(receiver,
-//                 callback,
-//                 resource_name,
-//                 Object::New(callback.Env())) {
-// }
+inline AsyncWorker::AsyncWorker(const Object& receiver,
+                                const Function& callback,
+                                const char* resource_name)
+  : AsyncWorker(receiver,
+                callback,
+                resource_name,
+                Object::New(callback.Env())) {
+}
 
-// inline AsyncWorker::AsyncWorker(const Object& receiver,
-//                                 const Function& callback,
-//                                 const char* resource_name,
-//                                 const Object& resource)
-//   : _env(callback.Env()),
-//     _receiver(Napi::Persistent(receiver)),
-//     _callback(Napi::Persistent(callback)),
-//     _suppress_destruct(false) {
-//   napi_value resource_id;
-//   napi_status status = napi_create_string_latin1(
-//       _env, resource_name, NAPI_AUTO_LENGTH, &resource_id);
-//   NAPI_THROW_IF_FAILED_VOID(_env, status);
+inline AsyncWorker::AsyncWorker(const Object& receiver,
+                                const Function& callback,
+                                const char* resource_name,
+                                const Object& resource)
+  : _env(callback.Env()),
+    _receiver(Napi::Persistent(receiver)),
+    _callback(Napi::Persistent(callback)),
+    _suppress_destruct(false) {
+  napi_value resource_id;
+  napi_status status = napi_create_string_latin1(
+      _env, resource_name, NAPI_AUTO_LENGTH, &resource_id);
+  NAPI_THROW_IF_FAILED_VOID(_env, status);
 
-//   status = napi_create_async_work(_env, resource, resource_id, OnAsyncWorkExecute,
-//                                   OnAsyncWorkComplete, this, &_work);
-//   NAPI_THROW_IF_FAILED_VOID(_env, status);
-// }
+  status = napi_create_async_work(_env, resource, resource_id, OnAsyncWorkExecute,
+                                  OnAsyncWorkComplete, this, &_work);
+  NAPI_THROW_IF_FAILED_VOID(_env, status);
+}
 
-// inline AsyncWorker::AsyncWorker(Napi::Env env)
-//   : AsyncWorker(env, "generic") {
-// }
+inline AsyncWorker::AsyncWorker(Napi::Env env)
+  : AsyncWorker(env, "generic") {
+}
 
-// inline AsyncWorker::AsyncWorker(Napi::Env env,
-//                                 const char* resource_name)
-//   : AsyncWorker(env, resource_name, Object::New(env)) {
-// }
+inline AsyncWorker::AsyncWorker(Napi::Env env,
+                                const char* resource_name)
+  : AsyncWorker(env, resource_name, Object::New(env)) {
+}
 
-// inline AsyncWorker::AsyncWorker(Napi::Env env,
-//                                 const char* resource_name,
-//                                 const Object& resource)
-//   : _env(env),
-//     _receiver(),
-//     _callback(),
-//     _suppress_destruct(false) {
-//   napi_value resource_id;
-//   napi_status status = napi_create_string_latin1(
-//       _env, resource_name, NAPI_AUTO_LENGTH, &resource_id);
-//   NAPI_THROW_IF_FAILED_VOID(_env, status);
+inline AsyncWorker::AsyncWorker(Napi::Env env,
+                                const char* resource_name,
+                                const Object& resource)
+  : _env(env),
+    _receiver(),
+    _callback(),
+    _suppress_destruct(false) {
+  napi_value resource_id;
+  napi_status status = napi_create_string_latin1(
+      _env, resource_name, NAPI_AUTO_LENGTH, &resource_id);
+  NAPI_THROW_IF_FAILED_VOID(_env, status);
 
-//   status = napi_create_async_work(_env, resource, resource_id, OnAsyncWorkExecute,
-//                                   OnAsyncWorkComplete, this, &_work);
-//   NAPI_THROW_IF_FAILED_VOID(_env, status);
-// }
+  status = napi_create_async_work(_env, resource, resource_id, OnAsyncWorkExecute,
+                                  OnAsyncWorkComplete, this, &_work);
+  NAPI_THROW_IF_FAILED_VOID(_env, status);
+}
 
-// inline AsyncWorker::~AsyncWorker() {
-//   if (_work != nullptr) {
-//     napi_delete_async_work(_env, _work);
-//     _work = nullptr;
-//   }
-// }
+inline AsyncWorker::~AsyncWorker() {
+  if (_work != nullptr) {
+    napi_delete_async_work(_env, _work);
+    _work = nullptr;
+  }
+}
 
-// inline void AsyncWorker::Destroy() {
-//   delete this;
-// }
+inline void AsyncWorker::Destroy() {
+  delete this;
+}
 
-// inline AsyncWorker::AsyncWorker(AsyncWorker&& other) {
-//   _env = other._env;
-//   other._env = nullptr;
-//   _work = other._work;
-//   other._work = nullptr;
-//   _receiver = std::move(other._receiver);
-//   _callback = std::move(other._callback);
-//   _error = std::move(other._error);
-//   _suppress_destruct = other._suppress_destruct;
-// }
+inline AsyncWorker::AsyncWorker(AsyncWorker&& other) {
+  _env = other._env;
+  other._env = nullptr;
+  _work = other._work;
+  other._work = nullptr;
+  _receiver = std::move(other._receiver);
+  _callback = std::move(other._callback);
+  _error = std::move(other._error);
+  _suppress_destruct = other._suppress_destruct;
+}
 
-// inline AsyncWorker& AsyncWorker::operator =(AsyncWorker&& other) {
-//   _env = other._env;
-//   other._env = nullptr;
-//   _work = other._work;
-//   other._work = nullptr;
-//   _receiver = std::move(other._receiver);
-//   _callback = std::move(other._callback);
-//   _error = std::move(other._error);
-//   _suppress_destruct = other._suppress_destruct;
-//   return *this;
-// }
+inline AsyncWorker& AsyncWorker::operator =(AsyncWorker&& other) {
+  _env = other._env;
+  other._env = nullptr;
+  _work = other._work;
+  other._work = nullptr;
+  _receiver = std::move(other._receiver);
+  _callback = std::move(other._callback);
+  _error = std::move(other._error);
+  _suppress_destruct = other._suppress_destruct;
+  return *this;
+}
 
-// inline AsyncWorker::operator napi_async_work() const {
-//   return _work;
-// }
+inline AsyncWorker::operator napi_async_work() const {
+  return _work;
+}
 
-// inline Napi::Env AsyncWorker::Env() const {
-//   return Napi::Env(_env);
-// }
+inline Napi::Env AsyncWorker::Env() const {
+  return Napi::Env(_env);
+}
 
-// inline void AsyncWorker::Queue() {
-//   napi_status status = napi_queue_async_work(_env, _work);
-//   NAPI_THROW_IF_FAILED_VOID(_env, status);
-// }
+inline void AsyncWorker::Queue() {
+  napi_status status = napi_queue_async_work(_env, _work);
+  NAPI_THROW_IF_FAILED_VOID(_env, status);
+}
 
-// inline void AsyncWorker::Cancel() {
-//   napi_status status = napi_cancel_async_work(_env, _work);
-//   NAPI_THROW_IF_FAILED_VOID(_env, status);
-// }
+inline void AsyncWorker::Cancel() {
+  napi_status status = napi_cancel_async_work(_env, _work);
+  NAPI_THROW_IF_FAILED_VOID(_env, status);
+}
 
-// inline ObjectReference& AsyncWorker::Receiver() {
-//   return _receiver;
-// }
+inline ObjectReference& AsyncWorker::Receiver() {
+  return _receiver;
+}
 
-// inline FunctionReference& AsyncWorker::Callback() {
-//   return _callback;
-// }
+inline FunctionReference& AsyncWorker::Callback() {
+  return _callback;
+}
 
-// inline void AsyncWorker::SuppressDestruct() {
-//   _suppress_destruct = true;
-// }
+inline void AsyncWorker::SuppressDestruct() {
+  _suppress_destruct = true;
+}
 
-// inline void AsyncWorker::OnOK() {
-//   if (!_callback.IsEmpty()) {
-//     _callback.Call(_receiver.Value(), GetResult(_callback.Env()));
-//   }
-// }
+inline void AsyncWorker::OnOK() {
+  if (!_callback.IsEmpty()) {
+    _callback.Call(_receiver.Value(), GetResult(_callback.Env()));
+  }
+}
 
-// inline void AsyncWorker::OnError(const Error& e) {
-//   if (!_callback.IsEmpty()) {
-//     _callback.Call(_receiver.Value(), std::initializer_list<napi_value>{ e.Value() });
-//   }
-// }
+inline void AsyncWorker::OnError(const Error& e) {
+  if (!_callback.IsEmpty()) {
+    _callback.Call(_receiver.Value(), std::initializer_list<napi_value>{ e.Value() });
+  }
+}
 
-// inline void AsyncWorker::SetError(const std::string& error) {
-//   _error = error;
-// }
+inline void AsyncWorker::SetError(const std::string& error) {
+  _error = error;
+}
 
-// inline std::vector<napi_value> AsyncWorker::GetResult(Napi::Env /*env*/) {
-//   return {};
-// }
-// // The OnAsyncWorkExecute method receives an napi_env argument. However, do NOT
-// // use it within this method, as it does not run on the JavaScript thread and
-// // must not run any method that would cause JavaScript to run. In practice,
-// // this means that almost any use of napi_env will be incorrect.
-// inline void AsyncWorker::OnAsyncWorkExecute(napi_env env, void* asyncworker) {
-//   AsyncWorker* self = static_cast<AsyncWorker*>(asyncworker);
-//   self->OnExecute(env);
-// }
-// // The OnExecute method receives an napi_env argument. However, do NOT
-// // use it within this method, as it does not run on the JavaScript thread and
-// // must not run any method that would cause JavaScript to run. In practice,
-// // this means that almost any use of napi_env will be incorrect.
-// inline void AsyncWorker::OnExecute(Napi::Env /*DO_NOT_USE*/) {
-// #ifdef NAPI_CPP_EXCEPTIONS
-//   try {
-//     Execute();
-//   } catch (const std::exception& e) {
-//     SetError(e.what());
-//   }
-// #else // NAPI_CPP_EXCEPTIONS
-//   Execute();
-// #endif // NAPI_CPP_EXCEPTIONS
-// }
+inline std::vector<napi_value> AsyncWorker::GetResult(Napi::Env /*env*/) {
+  return {};
+}
+// The OnAsyncWorkExecute method receives an napi_env argument. However, do NOT
+// use it within this method, as it does not run on the JavaScript thread and
+// must not run any method that would cause JavaScript to run. In practice,
+// this means that almost any use of napi_env will be incorrect.
+inline void AsyncWorker::OnAsyncWorkExecute(napi_env env, void* asyncworker) {
+  AsyncWorker* self = static_cast<AsyncWorker*>(asyncworker);
+  self->OnExecute(env);
+}
+// The OnExecute method receives an napi_env argument. However, do NOT
+// use it within this method, as it does not run on the JavaScript thread and
+// must not run any method that would cause JavaScript to run. In practice,
+// this means that almost any use of napi_env will be incorrect.
+inline void AsyncWorker::OnExecute(Napi::Env /*DO_NOT_USE*/) {
+#ifdef NAPI_CPP_EXCEPTIONS
+  try {
+    Execute();
+  } catch (const std::exception& e) {
+    SetError(e.what());
+  }
+#else // NAPI_CPP_EXCEPTIONS
+  Execute();
+#endif // NAPI_CPP_EXCEPTIONS
+}
 
-// inline void AsyncWorker::OnAsyncWorkComplete(napi_env env,
-//                                              napi_status status,
-//                                              void* asyncworker) {
-//   AsyncWorker* self = static_cast<AsyncWorker*>(asyncworker);
-//   self->OnWorkComplete(env, status);
-// }
-// inline void AsyncWorker::OnWorkComplete(Napi::Env /*env*/, napi_status status) {
-//   if (status != napi_cancelled) {
-//     HandleScope scope(_env);
-//     details::WrapCallback([&] {
-//       if (_error.size() == 0) {
-//         OnOK();
-//       }
-//       else {
-//         OnError(Error::New(_env, _error));
-//       }
-//       return nullptr;
-//     });
-//   }
-//   if (!_suppress_destruct) {
-//     Destroy();
-//   }
-// }
+inline void AsyncWorker::OnAsyncWorkComplete(napi_env env,
+                                             napi_status status,
+                                             void* asyncworker) {
+  AsyncWorker* self = static_cast<AsyncWorker*>(asyncworker);
+  self->OnWorkComplete(env, status);
+}
+inline void AsyncWorker::OnWorkComplete(Napi::Env /*env*/, napi_status status) {
+  if (status != napi_cancelled) {
+    HandleScope scope(_env);
+    details::WrapCallback([&] {
+      if (_error.size() == 0) {
+        OnOK();
+      }
+      else {
+        OnError(Error::New(_env, _error));
+      }
+      return nullptr;
+    });
+  }
+  if (!_suppress_destruct) {
+    Destroy();
+  }
+}
 
 #if (NAPI_VERSION > 3 && !defined(__wasm32__))
 ////////////////////////////////////////////////////////////////////////////////

--- a/packages/emnapi/include/napi.h
+++ b/packages/emnapi/include/napi.h
@@ -2335,75 +2335,75 @@ namespace NAPI_CPP_CUSTOM_NAMESPACE {
   //   napi_async_context _context;
   // };
 
-  // class AsyncWorker {
-  // public:
-  //   virtual ~AsyncWorker();
+  class AsyncWorker {
+  public:
+    virtual ~AsyncWorker();
 
-  //   // An async worker can be moved but cannot be copied.
-  //   AsyncWorker(AsyncWorker&& other);
-  //   AsyncWorker& operator =(AsyncWorker&& other);
-  //   NAPI_DISALLOW_ASSIGN_COPY(AsyncWorker)
+    // An async worker can be moved but cannot be copied.
+    AsyncWorker(AsyncWorker&& other);
+    AsyncWorker& operator =(AsyncWorker&& other);
+    NAPI_DISALLOW_ASSIGN_COPY(AsyncWorker)
 
-  //   operator napi_async_work() const;
+    operator napi_async_work() const;
 
-  //   Napi::Env Env() const;
+    Napi::Env Env() const;
 
-  //   void Queue();
-  //   void Cancel();
-  //   void SuppressDestruct();
+    void Queue();
+    void Cancel();
+    void SuppressDestruct();
 
-  //   ObjectReference& Receiver();
-  //   FunctionReference& Callback();
+    ObjectReference& Receiver();
+    FunctionReference& Callback();
 
-  //   virtual void OnExecute(Napi::Env env);
-  //   virtual void OnWorkComplete(Napi::Env env,
-  //                               napi_status status);
+    virtual void OnExecute(Napi::Env env);
+    virtual void OnWorkComplete(Napi::Env env,
+                                napi_status status);
 
-  // protected:
-  //   explicit AsyncWorker(const Function& callback);
-  //   explicit AsyncWorker(const Function& callback,
-  //                        const char* resource_name);
-  //   explicit AsyncWorker(const Function& callback,
-  //                        const char* resource_name,
-  //                        const Object& resource);
-  //   explicit AsyncWorker(const Object& receiver,
-  //                        const Function& callback);
-  //   explicit AsyncWorker(const Object& receiver,
-  //                        const Function& callback,
-  //                        const char* resource_name);
-  //   explicit AsyncWorker(const Object& receiver,
-  //                        const Function& callback,
-  //                        const char* resource_name,
-  //                        const Object& resource);
+  protected:
+    explicit AsyncWorker(const Function& callback);
+    explicit AsyncWorker(const Function& callback,
+                         const char* resource_name);
+    explicit AsyncWorker(const Function& callback,
+                         const char* resource_name,
+                         const Object& resource);
+    explicit AsyncWorker(const Object& receiver,
+                         const Function& callback);
+    explicit AsyncWorker(const Object& receiver,
+                         const Function& callback,
+                         const char* resource_name);
+    explicit AsyncWorker(const Object& receiver,
+                         const Function& callback,
+                         const char* resource_name,
+                         const Object& resource);
 
-  //   explicit AsyncWorker(Napi::Env env);
-  //   explicit AsyncWorker(Napi::Env env,
-  //                        const char* resource_name);
-  //   explicit AsyncWorker(Napi::Env env,
-  //                        const char* resource_name,
-  //                        const Object& resource);
+    explicit AsyncWorker(Napi::Env env);
+    explicit AsyncWorker(Napi::Env env,
+                         const char* resource_name);
+    explicit AsyncWorker(Napi::Env env,
+                         const char* resource_name,
+                         const Object& resource);
 
-  //   virtual void Execute() = 0;
-  //   virtual void OnOK();
-  //   virtual void OnError(const Error& e);
-  //   virtual void Destroy();
-  //   virtual std::vector<napi_value> GetResult(Napi::Env env);
+    virtual void Execute() = 0;
+    virtual void OnOK();
+    virtual void OnError(const Error& e);
+    virtual void Destroy();
+    virtual std::vector<napi_value> GetResult(Napi::Env env);
 
-  //   void SetError(const std::string& error);
+    void SetError(const std::string& error);
 
-  // private:
-  //   static inline void OnAsyncWorkExecute(napi_env env, void* asyncworker);
-  //   static inline void OnAsyncWorkComplete(napi_env env,
-  //                                          napi_status status,
-  //                                          void* asyncworker);
+  private:
+    static inline void OnAsyncWorkExecute(napi_env env, void* asyncworker);
+    static inline void OnAsyncWorkComplete(napi_env env,
+                                           napi_status status,
+                                           void* asyncworker);
 
-  //   napi_env _env;
-  //   napi_async_work _work;
-  //   ObjectReference _receiver;
-  //   FunctionReference _callback;
-  //   std::string _error;
-  //   bool _suppress_destruct;
-  // };
+    napi_env _env;
+    napi_async_work _work;
+    ObjectReference _receiver;
+    FunctionReference _callback;
+    std::string _error;
+    bool _suppress_destruct;
+  };
 
   #if (NAPI_VERSION > 3 && !defined(__wasm32__))
   class ThreadSafeFunction {

--- a/packages/emnapi/include/node_api_types.h
+++ b/packages/emnapi/include/node_api_types.h
@@ -1,0 +1,21 @@
+#ifndef SRC_NODE_API_TYPES_H_
+#define SRC_NODE_API_TYPES_H_
+
+#include "js_native_api_types.h"
+
+typedef struct napi_async_work__* napi_async_work;
+
+typedef void (*napi_async_execute_callback)(napi_env env,
+                                            void* data);
+typedef void (*napi_async_complete_callback)(napi_env env,
+                                             napi_status status,
+                                             void* data);
+
+typedef struct {
+  uint32_t major;
+  uint32_t minor;
+  uint32_t patch;
+  const char* release;
+} napi_node_version;
+
+#endif  // SRC_NODE_API_TYPES_H_

--- a/packages/emnapi/src/emnapi.c
+++ b/packages/emnapi/src/emnapi.c
@@ -129,7 +129,6 @@ struct napi_async_work__ {
   napi_async_execute_callback execute;
   napi_async_complete_callback complete;
   void* data;
-  napi_status status;
   pthread_t tid;
 };
 
@@ -139,7 +138,7 @@ typedef struct worker_count {
 } worker_count;
 
 // extern void _emnapi_create_async_work_js(napi_async_work work);
-extern void _emnapi_delete_async_work_js(napi_async_work work);
+// extern void _emnapi_delete_async_work_js(napi_async_work work);
 extern void _emnapi_queue_async_work_js(napi_async_work work);
 extern void _emnapi_on_execute_async_work_js(napi_async_work work);
 extern int _emnapi_get_worker_count(worker_count* count);
@@ -155,7 +154,6 @@ napi_async_work _emnapi_async_work_init(
   work->execute = execute;
   work->complete = complete;
   work->data = data;
-  work->status = napi_ok;
   work->tid = NULL;
   return work;
 }
@@ -167,7 +165,6 @@ void _emnapi_async_work_destroy(napi_async_work work) {
 void* _emnapi_on_execute_async_work(void* arg) {
   napi_async_work work = (napi_async_work) arg;
   work->execute(work->env, work->data);
-  work->status = napi_ok;
   _emnapi_on_execute_async_work_js(work); // postMessage to main thread
   return NULL;
 }
@@ -211,7 +208,7 @@ napi_status napi_delete_async_work(napi_env env, napi_async_work work) {
   CHECK_ENV(env);
   CHECK_ARG(env, work);
 
-  _emnapi_delete_async_work_js(work);  // clean listeners
+  // _emnapi_delete_async_work_js(work);  // clean listeners
   _emnapi_async_work_destroy(work);
   return napi_clear_last_error(env);
 #else

--- a/packages/emnapi/src/emnapi.c
+++ b/packages/emnapi/src/emnapi.c
@@ -1,6 +1,29 @@
 #include <emscripten.h>
+#include <stdlib.h>
 #include "emnapi.h"
 #include "node_api.h"
+
+#ifdef __EMSCRIPTEN_PTHREADS__
+// #include <emscripten/proxying.h>
+#include <pthread.h>
+#endif
+
+#define CHECK_ENV(env)          \
+  do {                          \
+    if ((env) == NULL) {        \
+      return napi_invalid_arg;  \
+    }                           \
+  } while (0)
+
+#define RETURN_STATUS_IF_FALSE(env, condition, status)                  \
+  do {                                                                  \
+    if (!(condition)) {                                                 \
+      return napi_set_last_error((env), (status), 0, NULL);             \
+    }                                                                   \
+  } while (0)
+
+#define CHECK_ARG(env, arg) \
+  RETURN_STATUS_IF_FALSE((env), ((arg) != NULL), napi_invalid_arg)
 
 EXTERN_C_START
 
@@ -38,11 +61,26 @@ const char* emnapi_error_messages[] = {
 #define EMNAPI_MOD_NAME_X_HELPER(modname) #modname
 #define EMNAPI_MOD_NAME_X(modname) EMNAPI_MOD_NAME_X_HELPER(modname)
 
+// #ifdef __EMSCRIPTEN_PTHREADS__
+// void* returner_main(void* queue) {
+//   emscripten_exit_with_live_runtime();
+// }
+
+// static pthread_t worker_thread = NULL;
+// static em_proxying_queue* proxy_queue = NULL;
+// #endif
+
 EMSCRIPTEN_KEEPALIVE
 void _emnapi_runtime_init(int* malloc_p,
                          int* free_p,
                          const char** key,
                          const char*** error_messages) {
+// #ifdef __EMSCRIPTEN_PTHREADS__
+  // proxy_queue = em_proxying_queue_create();
+  // pthread_create(&worker_thread, NULL, returner_main, proxy_queue);
+  // pthread_detach(worker_thread);
+// #endif
+
   if (malloc_p) *malloc_p = (int)(malloc);
   if (free_p) *free_p = (int)(free);
   if (key) {
@@ -82,6 +120,121 @@ emnapi_get_emscripten_version(napi_env env,
   };
   *version = &emscripten_version;
   return napi_clear_last_error(env);
+}
+
+#ifdef __EMSCRIPTEN_PTHREADS__
+
+struct napi_async_work__ {
+  napi_env env;
+  napi_async_execute_callback execute;
+  napi_async_complete_callback complete;
+  void* data;
+  napi_status status;
+  pthread_t tid;
+};
+
+// extern void _emnapi_create_async_work_js(napi_async_work work);
+extern void _emnapi_delete_async_work_js(napi_async_work work);
+extern void _emnapi_queue_async_work_js(napi_async_work work);
+extern void _emnapi_on_execute_async_work_js(napi_async_work work);
+extern int _emnapi_get_unused_worker_size();
+
+napi_async_work _emnapi_async_work_init(
+  napi_env env,
+  napi_async_execute_callback execute,
+  napi_async_complete_callback complete,
+  void* data
+) {
+  napi_async_work work = (napi_async_work)malloc(sizeof(struct napi_async_work__));
+  work->env = env;
+  work->execute = execute;
+  work->complete = complete;
+  work->data = data;
+  work->status = napi_ok;
+  work->tid = NULL;
+  return work;
+}
+
+void _emnapi_async_work_destroy(napi_async_work work) {
+  free(work);
+}
+
+void* _emnapi_on_execute_async_work(void* arg) {
+  napi_async_work work = (napi_async_work) arg;
+  work->execute(work->env, work->data);
+  work->status = napi_ok;
+  _emnapi_on_execute_async_work_js(work); // postMessage to main thread
+  return NULL;
+}
+#endif
+
+EMSCRIPTEN_KEEPALIVE
+void _emnapi_execute_async_work(napi_async_work work) {
+#ifdef __EMSCRIPTEN_PTHREADS__
+  pthread_t t;
+  pthread_create(&t, NULL, _emnapi_on_execute_async_work, work);
+  work->tid = t;
+  _emnapi_queue_async_work_js(work);  // listen complete event
+  pthread_detach(t);
+#endif
+}
+
+napi_status napi_create_async_work(napi_env env,
+                                   napi_value async_resource,
+                                   napi_value async_resource_name,
+                                   napi_async_execute_callback execute,
+                                   napi_async_complete_callback complete,
+                                   void* data,
+                                   napi_async_work* result) {
+#ifdef __EMSCRIPTEN_PTHREADS__
+  CHECK_ENV(env);
+  CHECK_ARG(env, execute);
+  CHECK_ARG(env, result);
+
+  napi_async_work work = _emnapi_async_work_init(env, execute, complete, data);
+  // _emnapi_create_async_work_js(work); // listen complete event
+  *result = work;
+
+  return napi_clear_last_error(env);
+#else
+  return napi_set_last_error(env, napi_generic_failure, 0, NULL);
+#endif
+}
+
+napi_status napi_delete_async_work(napi_env env, napi_async_work work) {
+#ifdef __EMSCRIPTEN_PTHREADS__
+  CHECK_ENV(env);
+  CHECK_ARG(env, work);
+
+  _emnapi_delete_async_work_js(work);  // clean listeners
+  _emnapi_async_work_destroy(work);
+  return napi_clear_last_error(env);
+#else
+  return napi_set_last_error(env, napi_generic_failure, 0, NULL);
+#endif
+}
+
+napi_status napi_queue_async_work(napi_env env, napi_async_work work) {
+#ifdef __EMSCRIPTEN_PTHREADS__
+  CHECK_ENV(env);
+  CHECK_ARG(env, work);
+
+  int unused_worker_size = _emnapi_get_unused_worker_size();
+  if (unused_worker_size > 0) {
+    _emnapi_execute_async_work(work);
+  } else {
+    _emnapi_queue_async_work_js(work);  // queue work
+  }
+
+  // work->tid = worker_thread;
+  // _emnapi_queue_async_work_js(work);  // listen complete event
+  // emscripten_proxy_async(proxy_queue, worker_thread,
+  //   _emnapi_on_execute_async_work, work);
+
+  return napi_clear_last_error(env);
+#else
+  return napi_set_last_error(env, napi_generic_failure, 0, NULL);
+#endif
 }
 
 EXTERN_C_END

--- a/packages/emnapi/src/emnapi.c
+++ b/packages/emnapi/src/emnapi.c
@@ -133,11 +133,16 @@ struct napi_async_work__ {
   pthread_t tid;
 };
 
+typedef struct worker_count {
+  int unused;
+  int running;
+} worker_count;
+
 // extern void _emnapi_create_async_work_js(napi_async_work work);
 extern void _emnapi_delete_async_work_js(napi_async_work work);
 extern void _emnapi_queue_async_work_js(napi_async_work work);
 extern void _emnapi_on_execute_async_work_js(napi_async_work work);
-extern int _emnapi_get_unused_worker_size();
+extern int _emnapi_get_worker_count(worker_count* count);
 
 napi_async_work _emnapi_async_work_init(
   napi_env env,
@@ -219,8 +224,9 @@ napi_status napi_queue_async_work(napi_env env, napi_async_work work) {
   CHECK_ENV(env);
   CHECK_ARG(env, work);
 
-  int unused_worker_size = _emnapi_get_unused_worker_size();
-  if (unused_worker_size > 0) {
+  worker_count count;
+  _emnapi_get_worker_count(&count);
+  if (count.unused > 0 || count.running == 0) {
     _emnapi_execute_async_work(work);
   } else {
     _emnapi_queue_async_work_js(work);  // queue work

--- a/packages/emnapi/src/init.ts
+++ b/packages/emnapi/src/init.ts
@@ -8,20 +8,18 @@ declare function _napi_register_wasm_v1 (env: napi_env, exports: napi_value): na
 declare function __emnapi_runtime_init (...args: [number, number, number, number]): void
 
 mergeInto(LibraryManager.library, {
-  $emnapiGetDynamicCalls: function () {
-    return {
-      call_vi (_ptr: number, a: int32_t): void {
-        return makeDynCall('vi', '_ptr')(a)
-      },
-      call_ii (_ptr: number, a: int32_t): int32_t {
-        return makeDynCall('ii', '_ptr')(a)
-      },
-      call_iii (_ptr: number, a: int32_t, b: int32_t): int32_t {
-        return makeDynCall('iii', '_ptr')(a, b)
-      },
-      call_viii (_ptr: number, a: int32_t, b: int32_t, c: int32_t): void {
-        return makeDynCall('viii', '_ptr')(a, b, c)
-      }
+  $emnapiGetDynamicCalls: {
+    call_vi: function (_ptr: number, a: int32_t): void {
+      return makeDynCall('vi', '_ptr')(a)
+    },
+    call_ii: function (_ptr: number, a: int32_t): int32_t {
+      return makeDynCall('ii', '_ptr')(a)
+    },
+    call_iii: function (_ptr: number, a: int32_t, b: int32_t): int32_t {
+      return makeDynCall('iii', '_ptr')(a, b)
+    },
+    call_viii: function (_ptr: number, a: int32_t, b: int32_t, c: int32_t): void {
+      return makeDynCall('viii', '_ptr')(a, b, c)
     }
   },
 
@@ -38,7 +36,7 @@ mergeInto(LibraryManager.library, {
     let exportsKey: string
     let env: emnapi.Env | undefined
 
-    const dynCalls = emnapiGetDynamicCalls()
+    const dynCalls = emnapiGetDynamicCalls
 
     let malloc: ((size: number) => number) | undefined
     let free: ((ptr: number) => void) | undefined

--- a/packages/emnapi/src/simple-async-operation.ts
+++ b/packages/emnapi/src/simple-async-operation.ts
@@ -90,17 +90,19 @@ function napi_cancel_async_work (env: napi_env, work: number): napi_status {
       emnapiAsyncWorkerQueue.splice(workQueueIndex, 1)
       const complete = HEAP32[(work + 8) >> 2]
       if (complete !== NULL) {
-        const envObject = emnapi.envStore.get(env)!
-        const scope = envObject.openScope(emnapi.HandleScope)
-        try {
-          envObject.callIntoModule((envObject) => {
-            envObject.call_viii(complete, env, napi_status.napi_cancelled, HEAP32[(work + 12) >> 2])
-          })
-        } catch (err) {
+        setTimeout(() => {
+          const envObject = emnapi.envStore.get(env)!
+          const scope = envObject.openScope(emnapi.HandleScope)
+          try {
+            envObject.callIntoModule((envObject) => {
+              envObject.call_viii(complete, env, napi_status.napi_cancelled, HEAP32[(work + 12) >> 2])
+            })
+          } catch (err) {
+            envObject.closeScope(scope)
+            throw err
+          }
           envObject.closeScope(scope)
-          throw err
-        }
-        envObject.closeScope(scope)
+        })
       }
 
       return envObject.clearLastError()

--- a/packages/emnapi/src/simple-async-operation.ts
+++ b/packages/emnapi/src/simple-async-operation.ts
@@ -18,9 +18,11 @@ mergeInto(LibraryManager.library, {
     'return r;' +
   '};',
 
-  _emnapi_get_unused_worker_size__deps: ['$PThread'],
-  _emnapi_get_unused_worker_size: function () {
-    return PThread.unusedWorkers.length
+  _emnapi_get_worker_count__deps: ['$PThread'],
+  _emnapi_get_worker_count: function (struct: number) {
+    const address = struct >> 2
+    HEAP32[address] = PThread.unusedWorkers.length
+    HEAP32[address + 1] = PThread.runningWorkers.length
   },
 
   _emnapi_on_execute_async_work_js: function (work: number) {

--- a/packages/emnapi/src/simple-async-operation.ts
+++ b/packages/emnapi/src/simple-async-operation.ts
@@ -18,8 +18,8 @@ mergeInto(LibraryManager.library, {
     'return r;' +
   '};',
 
-  _emnapi_get_worker_count__deps: ['$PThread'],
-  _emnapi_get_worker_count: function (struct: number) {
+  _emnapi_get_worker_count_js__deps: ['$PThread'],
+  _emnapi_get_worker_count_js: function (struct: number) {
     const address = struct >> 2
     HEAP32[address] = PThread.unusedWorkers.length
     HEAP32[address + 1] = PThread.runningWorkers.length

--- a/packages/emnapi/src/simple-async-operation.ts
+++ b/packages/emnapi/src/simple-async-operation.ts
@@ -1,0 +1,116 @@
+/* eslint-disable @typescript-eslint/indent */
+/* eslint-disable no-unreachable */
+
+declare const PThread: any
+declare const emnapiAsyncWorkerQueue: number[]
+// declare function __emnapi_execute_async_work (work: number): void
+
+mergeInto(LibraryManager.library, {
+  $emnapiAsyncWorkerQueue: [],
+  $emnapiAsyncWorkerQueue__deps: ['$PThread', '_emnapi_execute_async_work'],
+  $emnapiAsyncWorkerQueue__postset: 'PThread.unusedWorkers.push=function(){' +
+    'var r=Array.prototype.push.apply(this,arguments);' +
+    'setTimeout(function(){' +
+      'if(PThread.unusedWorkers.length>0&&emnapiAsyncWorkerQueue.length>0){' +
+        '__emnapi_execute_async_work(emnapiAsyncWorkerQueue.shift());' +
+      '}' +
+    '});' +
+    'return r;' +
+  '};',
+
+  _emnapi_get_unused_worker_size__deps: ['$PThread'],
+  _emnapi_get_unused_worker_size: function () {
+    return PThread.unusedWorkers.length
+  },
+
+  _emnapi_on_execute_async_work_js: function (work: number) {
+    if (ENVIRONMENT_IS_PTHREAD) {
+      postMessage({ emnapiAsyncWorkPtr: work })
+    }
+  },
+
+  _emnapi_delete_async_work_js: function (_work: number) {
+    // TODO
+  }
+})
+
+function _emnapi_queue_async_work_js (work: number): void {
+  const tid = HEAP32[(work + 20) >> 2]
+  if (tid === 0) {
+    emnapiAsyncWorkerQueue.push(work)
+    return
+  }
+  const env = HEAP32[work >> 2]
+  const worker: Worker = PThread.pthreads[tid].worker
+  const listener: (this: Worker, ev: MessageEvent<any>) => any = (e) => {
+    const removeListener = (): void => {
+      if (ENVIRONMENT_IS_NODE) {
+        (worker as any).off('message', listener)
+      } else {
+        worker.removeEventListener('message', listener, false)
+      }
+    }
+    const data = ENVIRONMENT_IS_NODE ? e : e.data
+    if (data.emnapiAsyncWorkPtr === work) {
+      HEAP32[(work + 20) >> 2] = 0 // tid
+      const complete = HEAP32[(work + 8) >> 2]
+      if (complete !== NULL) {
+        const envObject = emnapi.envStore.get(env)!
+        const scope = envObject.openScope(emnapi.HandleScope)
+        try {
+          envObject.callIntoModule((envObject) => {
+            envObject.call_viii(complete, env, HEAP32[(work + 16) >> 2], HEAP32[(work + 12) >> 2])
+          })
+        } catch (err) {
+          envObject.closeScope(scope)
+          removeListener()
+          throw err
+        }
+        envObject.closeScope(scope)
+      }
+      removeListener()
+    }
+  }
+  if (ENVIRONMENT_IS_NODE) {
+    (worker as any).on('message', listener)
+  } else {
+    worker.addEventListener('message', listener, false)
+  }
+}
+
+function napi_cancel_async_work (env: napi_env, work: number): napi_status {
+// #if USE_PTHREADS
+  return emnapi.checkEnv(env, (envObject) => {
+    return emnapi.checkArgs(envObject, [work], () => {
+      const tid = HEAP32[(work + 20) >> 2]
+      if (tid !== 0) {
+        return envObject.setLastError(napi_status.napi_generic_failure)
+      }
+
+      emnapiAsyncWorkerQueue.splice(emnapiAsyncWorkerQueue.indexOf(work), 1)
+      HEAP32[(work + 16) >> 2] = napi_status.napi_cancelled
+      const complete = HEAP32[(work + 8) >> 2]
+      if (complete !== NULL) {
+        const envObject = emnapi.envStore.get(env)!
+        const scope = envObject.openScope(emnapi.HandleScope)
+        try {
+          envObject.callIntoModule((envObject) => {
+            envObject.call_viii(complete, env, napi_status.napi_cancelled, HEAP32[(work + 12) >> 2])
+          })
+        } catch (err) {
+          envObject.closeScope(scope)
+          throw err
+        }
+        envObject.closeScope(scope)
+      }
+
+      return envObject.clearLastError()
+    })
+  })
+// #else
+  return _napi_set_last_error(env, napi_status.napi_generic_failure, 0, 0)
+// #endif
+}
+
+emnapiImplement('_emnapi_queue_async_work_js', _emnapi_queue_async_work_js, ['$PThread', '$emnapiAsyncWorkerQueue'])
+emnapiImplement('napi_cancel_async_work', napi_cancel_async_work, ['$emnapiAsyncWorkerQueue'])

--- a/packages/emnapi/src/typings/runtime.d.ts
+++ b/packages/emnapi/src/typings/runtime.d.ts
@@ -5,12 +5,14 @@ declare interface IDynamicCalls {
   call_viii (_ptr: number, a: int32_t, b: int32_t, c: int32_t): void
   // call_malloc (_size: size_t): void_p
 }
-declare function emnapiGetDynamicCalls (): IDynamicCalls
+declare const emnapiGetDynamicCalls: IDynamicCalls
 
 declare const HEAPU32: Uint32Array
 declare const HEAP32: Int32Array
 declare const HEAPF64: Float64Array
 declare const HEAPU8: Uint8Array
+declare const ENVIRONMENT_IS_NODE: boolean
+declare const ENVIRONMENT_IS_PTHREAD: boolean
 declare const wasmTable: WebAssembly.Table
 
 declare function UTF8ToString (ptr: const_char_p, maxRead?: number): string

--- a/packages/test/async/async.html
+++ b/packages/test/async/async.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>async</title>
+</head>
+<body>
+  <script src="../../runtime/dist/emnapi.min.js"></script>
+  <script src="../.cgenbuild/Debug/async.js"></script>
+  <script>
+    (async function main () {
+      const loadPromise = window['async'].default()
+      const test_async = (await loadPromise).Module.emnapiExports
+
+      const testException = 'test_async_cb_exception'
+
+      const assert = {
+        strictEqual (a, b) {
+          if (a !== b) {
+            throw new Error('')
+          }
+        }
+      }
+
+      await new Promise((resolve) => {
+        // Successful async execution and completion callback.
+        test_async.Test(5, {}, function (err, val) {
+          console.log('test_async.Test(5, {}, callback)')
+          assert.strictEqual(err, null)
+          assert.strictEqual(val, 10)
+          resolve()
+        })
+      })
+
+      await new Promise((resolve) => {
+        // Async work item cancellation with callback.
+        test_async.TestCancel(() => {
+          console.log('test_async.TestCancel(callback)')
+          resolve()
+        })
+      })
+
+      const iterations = 500
+      let x = 0
+      const workDone = (status) => {
+        assert.strictEqual(status, 0)
+        if (++x < iterations) {
+          setTimeout(() => test_async.DoRepeatedWork(workDone))
+        } else {
+          console.log(x)
+        }
+      }
+      test_async.DoRepeatedWork(workDone)
+
+      await new Promise((resolve) => {
+        setTimeout(resolve, 3000)
+      })
+    })()
+  </script>
+</body>
+</html>

--- a/packages/test/async/async.test.js
+++ b/packages/test/async/async.test.js
@@ -45,6 +45,17 @@ async function main () {
     }))
   })
 
+  const iterations = 500
+  let x = 0
+  const workDone = common.mustCall((status) => {
+    assert.strictEqual(status, 0)
+    console.log(status)
+    if (++x < iterations) {
+      setImmediate(() => test_async.DoRepeatedWork(workDone))
+    }
+  }, iterations)
+  test_async.DoRepeatedWork(workDone)
+
   await new Promise((resolve) => {
     setTimeout(resolve, 4000)
   })

--- a/packages/test/async/async.test.js
+++ b/packages/test/async/async.test.js
@@ -1,0 +1,53 @@
+/* eslint-disable camelcase */
+'use strict'
+const { load } = require('../util')
+const common = require('../common')
+const assert = require('assert')
+const child_process = require('child_process')
+
+async function main () {
+  const test_async = await load('async')
+
+  const testException = 'test_async_cb_exception'
+
+  // Exception thrown from async completion callback.
+  // (Tested in a spawned process because the exception is fatal.)
+  if (process.argv[2] === 'child') {
+    test_async.Test(1, {}, common.mustCall(function () {
+      throw new Error(testException)
+    }))
+    return
+  }
+  const p = child_process.spawnSync(
+    process.execPath, [__filename, 'child'])
+  assert.ifError(p.error)
+  const stderr = p.stderr.toString()
+  assert.ok(stderr.includes(testException))
+
+  await new Promise((resolve) => {
+    // Successful async execution and completion callback.
+    test_async.Test(5, {}, common.mustCall(function (err, val) {
+      console.log(11111)
+      assert.strictEqual(err, null)
+      assert.strictEqual(val, 10)
+      process.nextTick(common.mustCall(() => {
+        console.log(22222)
+        resolve()
+      }))
+    }))
+  })
+
+  await new Promise((resolve) => {
+    // Async work item cancellation with callback.
+    test_async.TestCancel(common.mustCall(() => {
+      console.log(33333)
+      resolve()
+    }))
+  })
+
+  await new Promise((resolve) => {
+    setTimeout(resolve, 4000)
+  })
+}
+
+module.exports = main()

--- a/packages/test/async/async.test.js
+++ b/packages/test/async/async.test.js
@@ -49,7 +49,6 @@ async function main () {
   let x = 0
   const workDone = common.mustCall((status) => {
     assert.strictEqual(status, 0)
-    console.log(status)
     if (++x < iterations) {
       setImmediate(() => test_async.DoRepeatedWork(workDone))
     }

--- a/packages/test/async/async.test.js
+++ b/packages/test/async/async.test.js
@@ -34,11 +34,11 @@ async function main () {
   await new Promise((resolve) => {
     // Successful async execution and completion callback.
     test_async.Test(5, {}, common.mustCall(function (err, val) {
-      console.log(11111)
+      console.log('test_async.Test(5, {}, callback)')
       assert.strictEqual(err, null)
       assert.strictEqual(val, 10)
       process.nextTick(common.mustCall(() => {
-        console.log(22222)
+        console.log('process.nextTick(callback)')
         resolve()
       }))
     }))
@@ -47,7 +47,7 @@ async function main () {
   await new Promise((resolve) => {
     // Async work item cancellation with callback.
     test_async.TestCancel(common.mustCall(() => {
-      console.log(33333)
+      console.log('test_async.TestCancel(callback)')
       resolve()
     }))
   })
@@ -70,6 +70,7 @@ async function main () {
         assert.strictEqual(err.message, 'should not fail')
       }
       assert.strictEqual(err.message, 'uncaught')
+      console.log('process.once("uncaughtException", callback): ' + err.message)
       resolve()
     }))
 

--- a/packages/test/async/binding.c
+++ b/packages/test/async/binding.c
@@ -1,0 +1,231 @@
+#include <assert.h>
+#include <stdio.h>
+#include <node_api.h>
+#include "../common.h"
+#include <stdio.h>
+
+#if defined _WIN32
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
+// this needs to be greater than the thread pool size
+#define MAX_CANCEL_THREADS 6
+
+typedef struct {
+  int32_t _input;
+  int32_t _output;
+  napi_ref _callback;
+  napi_async_work _request;
+} carrier;
+
+static carrier the_carrier;
+static carrier async_carrier[MAX_CANCEL_THREADS];
+
+static void Execute(napi_env env, void* data) {
+#if defined _WIN32
+  Sleep(1000);
+#else
+  sleep(1);
+#endif
+  carrier* c = (carrier*)(data);
+
+  assert(c == &the_carrier);
+
+  c->_output = c->_input * 2;
+}
+
+static void Complete(napi_env env, napi_status status, void* data) {
+  carrier* c = (carrier*)(data);
+
+  if (c != &the_carrier) {
+    napi_throw_type_error(env, NULL, "Wrong data parameter to Complete.");
+    return;
+  }
+
+  if (status != napi_ok) {
+    napi_throw_type_error(env, NULL, "Execute callback failed.");
+    return;
+  }
+
+  napi_value argv[2];
+
+  NAPI_CALL_RETURN_VOID(env, napi_get_null(env, &argv[0]));
+  NAPI_CALL_RETURN_VOID(env, napi_create_int32(env, c->_output, &argv[1]));
+  napi_value callback;
+  NAPI_CALL_RETURN_VOID(env,
+      napi_get_reference_value(env, c->_callback, &callback));
+  napi_value global;
+  NAPI_CALL_RETURN_VOID(env, napi_get_global(env, &global));
+
+  napi_value result;
+  NAPI_CALL_RETURN_VOID(env,
+    napi_call_function(env, global, callback, 2, argv, &result));
+
+  NAPI_CALL_RETURN_VOID(env, napi_delete_reference(env, c->_callback));
+  NAPI_CALL_RETURN_VOID(env, napi_delete_async_work(env, c->_request));
+}
+
+static napi_value Test(napi_env env, napi_callback_info info) {
+  size_t argc = 3;
+  napi_value argv[3];
+  napi_value _this;
+  napi_value resource_name;
+  void* data;
+  NAPI_CALL(env,
+    napi_get_cb_info(env, info, &argc, argv, &_this, &data));
+  NAPI_ASSERT(env, argc >= 3, "Not enough arguments, expected 2.");
+
+  napi_valuetype t;
+  NAPI_CALL(env, napi_typeof(env, argv[0], &t));
+  NAPI_ASSERT(env, t == napi_number,
+      "Wrong first argument, integer expected.");
+  NAPI_CALL(env, napi_typeof(env, argv[1], &t));
+  NAPI_ASSERT(env, t == napi_object,
+    "Wrong second argument, object expected.");
+  NAPI_CALL(env, napi_typeof(env, argv[2], &t));
+  NAPI_ASSERT(env, t == napi_function,
+    "Wrong third argument, function expected.");
+
+  the_carrier._output = 0;
+
+  NAPI_CALL(env,
+      napi_get_value_int32(env, argv[0], &the_carrier._input));
+  NAPI_CALL(env,
+    napi_create_reference(env, argv[2], 1, &the_carrier._callback));
+
+  NAPI_CALL(env, napi_create_string_utf8(
+      env, "TestResource", NAPI_AUTO_LENGTH, &resource_name));
+  NAPI_CALL(env, napi_create_async_work(env, argv[1], resource_name,
+    Execute, Complete, &the_carrier, &the_carrier._request));
+  NAPI_CALL(env,
+      napi_queue_async_work(env, the_carrier._request));
+
+  return NULL;
+}
+
+static void BusyCancelComplete(napi_env env, napi_status status, void* data) {
+  carrier* c = (carrier*)(data);
+  NAPI_CALL_RETURN_VOID(env, napi_delete_async_work(env, c->_request));
+}
+
+static void CancelComplete(napi_env env, napi_status status, void* data) {
+  carrier* c = (carrier*)(data);
+
+  if (status == napi_cancelled) {
+    // ok we got the status we expected so make the callback to
+    // indicate the cancel succeeded.
+    napi_value callback;
+    NAPI_CALL_RETURN_VOID(env,
+        napi_get_reference_value(env, c->_callback, &callback));
+    napi_value global;
+    NAPI_CALL_RETURN_VOID(env, napi_get_global(env, &global));
+    napi_value result;
+    NAPI_CALL_RETURN_VOID(env,
+      napi_call_function(env, global, callback, 0, NULL, &result));
+  }
+
+  NAPI_CALL_RETURN_VOID(env, napi_delete_async_work(env, c->_request));
+  NAPI_CALL_RETURN_VOID(env, napi_delete_reference(env, c->_callback));
+}
+
+static void CancelExecute(napi_env env, void* data) {
+#if defined _WIN32
+  Sleep(1000);
+#else
+  sleep(1);
+#endif
+  printf("CancelExecute: 0x%08x\n", (int)data);
+}
+
+static napi_value TestCancel(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value argv[1];
+  napi_value _this;
+  napi_value resource_name;
+  void* data;
+
+  NAPI_CALL(env, napi_create_string_utf8(
+      env, "TestResource", NAPI_AUTO_LENGTH, &resource_name));
+
+  // make sure the work we are going to cancel will not be
+  // able to start by using all the threads in the pool
+  for (int i = 1; i < MAX_CANCEL_THREADS; i++) {
+    NAPI_CALL(env, napi_create_async_work(env, NULL, resource_name,
+      CancelExecute, BusyCancelComplete,
+      &async_carrier[i], &async_carrier[i]._request));
+    NAPI_CALL(env, napi_queue_async_work(env, async_carrier[i]._request));
+  }
+
+  // now queue the work we are going to cancel and then cancel it.
+  // cancel will fail if the work has already started, but
+  // we have prevented it from starting by consuming all of the
+  // workers above.
+  NAPI_CALL(env,
+    napi_get_cb_info(env, info, &argc, argv, &_this, &data));
+  NAPI_CALL(env, napi_create_async_work(env, NULL, resource_name,
+    CancelExecute, CancelComplete,
+    &async_carrier[0], &async_carrier[0]._request));
+  NAPI_CALL(env,
+      napi_create_reference(env, argv[0], 1, &async_carrier[0]._callback));
+  NAPI_CALL(env, napi_queue_async_work(env, async_carrier[0]._request));
+  NAPI_CALL(env, napi_cancel_async_work(env, async_carrier[0]._request));
+  return NULL;
+}
+
+struct {
+  napi_ref ref;
+  napi_async_work work;
+} repeated_work_info = { NULL, NULL };
+
+static void RepeatedWorkerThread(napi_env env, void* data) {}
+
+static void RepeatedWorkComplete(napi_env env, napi_status status, void* data) {
+  napi_value cb, js_status;
+  NAPI_CALL_RETURN_VOID(env,
+      napi_get_reference_value(env, repeated_work_info.ref, &cb));
+  NAPI_CALL_RETURN_VOID(env,
+      napi_delete_async_work(env, repeated_work_info.work));
+  NAPI_CALL_RETURN_VOID(env,
+      napi_delete_reference(env, repeated_work_info.ref));
+  repeated_work_info.work = NULL;
+  repeated_work_info.ref = NULL;
+  NAPI_CALL_RETURN_VOID(env,
+      napi_create_uint32(env, (uint32_t)status, &js_status));
+  NAPI_CALL_RETURN_VOID(env,
+      napi_call_function(env, cb, cb, 1, &js_status, NULL));
+}
+
+static napi_value DoRepeatedWork(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value cb, name;
+  NAPI_ASSERT(env, repeated_work_info.ref == NULL,
+      "Reference left over from previous work");
+  NAPI_ASSERT(env, repeated_work_info.work == NULL,
+      "Work pointer left over from previous work");
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, &cb, NULL, NULL));
+  NAPI_CALL(env, napi_create_reference(env, cb, 1, &repeated_work_info.ref));
+  NAPI_CALL(env,
+      napi_create_string_utf8(env, "Repeated Work", NAPI_AUTO_LENGTH, &name));
+  NAPI_CALL(env,
+      napi_create_async_work(env, NULL, name, RepeatedWorkerThread,
+          RepeatedWorkComplete, &repeated_work_info, &repeated_work_info.work));
+  NAPI_CALL(env, napi_queue_async_work(env, repeated_work_info.work));
+  return NULL;
+}
+
+static napi_value Init(napi_env env, napi_value exports) {
+  napi_property_descriptor properties[] = {
+    DECLARE_NAPI_PROPERTY("Test", Test),
+    DECLARE_NAPI_PROPERTY("TestCancel", TestCancel),
+    DECLARE_NAPI_PROPERTY("DoRepeatedWork", DoRepeatedWork),
+  };
+
+  NAPI_CALL(env, napi_define_properties(
+      env, exports, sizeof(properties) / sizeof(*properties), properties));
+
+  return exports;
+}
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/packages/test/cgen.config.js
+++ b/packages/test/cgen.config.js
@@ -8,6 +8,7 @@ module.exports = function (_options, { isDebug, isEmscripten }) {
   const linkerFlags = isEmscripten
     ? [
         // "-sEXPORTED_FUNCTIONS=['_malloc','_free']",
+        '-sNODEJS_CATCH_EXIT=0',
         '-sWASM_BIGINT=1',
         '-sALLOW_MEMORY_GROWTH=1',
         '-sMIN_CHROME_VERSION=67',

--- a/packages/test/util.js
+++ b/packages/test/util.js
@@ -22,6 +22,7 @@ exports.load = function (targetName) {
             }
           }
         }).then(({ Module, emnapi }) => {
+          p.Module = Module
           p.emnapi = emnapi
           resolve(Module.emnapiExports)
         })


### PR DESCRIPTION
This PR implement these APIs in node_api.h

- [napi_create_async_work](https://nodejs.org/dist/latest-v16.x/docs/api/n-api.html#napi_create_async_work)
- [napi_delete_async_work](https://nodejs.org/dist/latest-v16.x/docs/api/n-api.html#napi_delete_async_work)
- [napi_queue_async_work](https://nodejs.org/dist/latest-v16.x/docs/api/n-api.html#napi_queue_async_work)
- [napi_cancel_async_work](https://nodejs.org/dist/latest-v16.x/docs/api/n-api.html#napi_cancel_async_work)

As discussion in emscripten-core/emscripten#17213, current implementation depends Emscripten pthread (`-sUSE_PTHREADS=1`). Also recommand to specifying thread pool size explicitly (`-sPTHREAD_POOL_SIZE=4`).