### PR TITLE
Support asynchronous thread-safe function calls

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -51,7 +51,7 @@
       "defines": ["${defines}", "__wasm32__"],
       "compilerPath": "${env:EMSDK}/upstream/emscripten/emcc",
       "intelliSenseMode": "clang-x86",
-      "cStandard": "c99",
+      "cStandard": "c11",
       "cppStandard": "c++11",
       "includePath": ["${includePath}"]
     },
@@ -60,7 +60,7 @@
       "defines": ["${defines}", "__wasm32__", "__EMSCRIPTEN_PTHREADS__"],
       "compilerPath": "${env:EMSDK}\\upstream\\emscripten\\emcc.bat",
       "intelliSenseMode": "clang-x86",
-      "cStandard": "c99",
+      "cStandard": "c11",
       "cppStandard": "c++11",
       "includePath": ["${includePath}"]
     }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
       "request": "launch",
       "name": "Launch Program",
       "runtimeArgs": ["--expose-gc"],
-      "program": "${workspaceFolder}/packages/test/async/async.test.js",
+      "program": "${workspaceFolder}/packages/test/tsfn/tsfn.test.js",
       "args": []
     },
     {

--- a/packages/emnapi/include/node_api.h
+++ b/packages/emnapi/include/node_api.h
@@ -77,6 +77,49 @@ NAPI_EXTERN
 napi_status napi_get_node_version(napi_env env,
                                   const napi_node_version** version);
 
+#if NAPI_VERSION >= 4
+
+#if !defined(__wasm32__) || defined(__EMSCRIPTEN__)
+// Calling into JS from other threads
+NAPI_EXTERN napi_status
+napi_create_threadsafe_function(napi_env env,
+                                napi_value func,
+                                napi_value async_resource,
+                                napi_value async_resource_name,
+                                size_t max_queue_size,
+                                size_t initial_thread_count,
+                                void* thread_finalize_data,
+                                napi_finalize thread_finalize_cb,
+                                void* context,
+                                napi_threadsafe_function_call_js call_js_cb,
+                                napi_threadsafe_function* result);
+
+NAPI_EXTERN napi_status
+napi_get_threadsafe_function_context(napi_threadsafe_function func,
+                                     void** result);
+
+NAPI_EXTERN napi_status
+napi_call_threadsafe_function(napi_threadsafe_function func,
+                              void* data,
+                              napi_threadsafe_function_call_mode is_blocking);
+
+NAPI_EXTERN napi_status
+napi_acquire_threadsafe_function(napi_threadsafe_function func);
+
+NAPI_EXTERN napi_status
+napi_release_threadsafe_function(napi_threadsafe_function func,
+                                 napi_threadsafe_function_release_mode mode);
+
+NAPI_EXTERN napi_status
+napi_unref_threadsafe_function(napi_env env, napi_threadsafe_function func);
+
+NAPI_EXTERN napi_status
+napi_ref_threadsafe_function(napi_env env, napi_threadsafe_function func);
+
+#endif
+
+#endif
+
 EXTERN_C_END
 
 #endif

--- a/packages/emnapi/include/node_api_types.h
+++ b/packages/emnapi/include/node_api_types.h
@@ -4,12 +4,34 @@
 #include "js_native_api_types.h"
 
 typedef struct napi_async_work__* napi_async_work;
+#if NAPI_VERSION >= 4
+typedef struct napi_threadsafe_function__* napi_threadsafe_function;
+#endif  // NAPI_VERSION >= 4
+
+#if NAPI_VERSION >= 4
+typedef enum {
+  napi_tsfn_release,
+  napi_tsfn_abort
+} napi_threadsafe_function_release_mode;
+
+typedef enum {
+  napi_tsfn_nonblocking,
+  napi_tsfn_blocking
+} napi_threadsafe_function_call_mode;
+#endif  // NAPI_VERSION >= 4
 
 typedef void (*napi_async_execute_callback)(napi_env env,
                                             void* data);
 typedef void (*napi_async_complete_callback)(napi_env env,
                                              napi_status status,
                                              void* data);
+
+#if NAPI_VERSION >= 4
+typedef void (*napi_threadsafe_function_call_js)(napi_env env,
+                                                 napi_value js_callback,
+                                                 void* context,
+                                                 void* data);
+#endif  // NAPI_VERSION >= 4
 
 typedef struct {
   uint32_t major;

--- a/packages/emnapi/src/init.ts
+++ b/packages/emnapi/src/init.ts
@@ -19,11 +19,17 @@ mergeInto(LibraryManager.library, {
     call_ii: function (_ptr: number, a: int32_t): int32_t {
       return makeDynCall('ii', '_ptr')(a)
     },
+    call_vii (_ptr: number, a: int32_t, b: int32_t): void {
+      return makeDynCall('vii', '_ptr')(a, b)
+    },
     call_iii: function (_ptr: number, a: int32_t, b: int32_t): int32_t {
       return makeDynCall('iii', '_ptr')(a, b)
     },
     call_viii: function (_ptr: number, a: int32_t, b: int32_t, c: int32_t): void {
       return makeDynCall('viii', '_ptr')(a, b, c)
+    },
+    call_viiii: function (_ptr: number, a: int32_t, b: int32_t, c: int32_t, d: int32_t): void {
+      return makeDynCall('viiii', '_ptr')(a, b, c, d)
     },
     call_malloc: function (_source: string, _size: string | number): void_p {
       return makeMalloc('_source', '_size')

--- a/packages/emnapi/src/queue.h
+++ b/packages/emnapi/src/queue.h
@@ -1,0 +1,108 @@
+/* Copyright (c) 2013, Ben Noordhuis <info@bnoordhuis.nl>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef QUEUE_H_
+#define QUEUE_H_
+
+#include <stddef.h>
+
+typedef void *QUEUE[2];
+
+/* Private macros. */
+#define QUEUE_NEXT(q)       (*(QUEUE **) &((*(q))[0]))
+#define QUEUE_PREV(q)       (*(QUEUE **) &((*(q))[1]))
+#define QUEUE_PREV_NEXT(q)  (QUEUE_NEXT(QUEUE_PREV(q)))
+#define QUEUE_NEXT_PREV(q)  (QUEUE_PREV(QUEUE_NEXT(q)))
+
+/* Public macros. */
+#define QUEUE_DATA(ptr, type, field)                                          \
+  ((type *) ((char *) (ptr) - offsetof(type, field)))
+
+/* Important note: mutating the list while QUEUE_FOREACH is
+ * iterating over its elements results in undefined behavior.
+ */
+#define QUEUE_FOREACH(q, h)                                                   \
+  for ((q) = QUEUE_NEXT(h); (q) != (h); (q) = QUEUE_NEXT(q))
+
+#define QUEUE_EMPTY(q)                                                        \
+  ((const QUEUE *) (q) == (const QUEUE *) QUEUE_NEXT(q))
+
+#define QUEUE_HEAD(q)                                                         \
+  (QUEUE_NEXT(q))
+
+#define QUEUE_INIT(q)                                                         \
+  do {                                                                        \
+    QUEUE_NEXT(q) = (q);                                                      \
+    QUEUE_PREV(q) = (q);                                                      \
+  }                                                                           \
+  while (0)
+
+#define QUEUE_ADD(h, n)                                                       \
+  do {                                                                        \
+    QUEUE_PREV_NEXT(h) = QUEUE_NEXT(n);                                       \
+    QUEUE_NEXT_PREV(n) = QUEUE_PREV(h);                                       \
+    QUEUE_PREV(h) = QUEUE_PREV(n);                                            \
+    QUEUE_PREV_NEXT(h) = (h);                                                 \
+  }                                                                           \
+  while (0)
+
+#define QUEUE_SPLIT(h, q, n)                                                  \
+  do {                                                                        \
+    QUEUE_PREV(n) = QUEUE_PREV(h);                                            \
+    QUEUE_PREV_NEXT(n) = (n);                                                 \
+    QUEUE_NEXT(n) = (q);                                                      \
+    QUEUE_PREV(h) = QUEUE_PREV(q);                                            \
+    QUEUE_PREV_NEXT(h) = (h);                                                 \
+    QUEUE_PREV(q) = (n);                                                      \
+  }                                                                           \
+  while (0)
+
+#define QUEUE_MOVE(h, n)                                                      \
+  do {                                                                        \
+    if (QUEUE_EMPTY(h))                                                       \
+      QUEUE_INIT(n);                                                          \
+    else {                                                                    \
+      QUEUE* q = QUEUE_HEAD(h);                                               \
+      QUEUE_SPLIT(h, q, n);                                                   \
+    }                                                                         \
+  }                                                                           \
+  while (0)
+
+#define QUEUE_INSERT_HEAD(h, q)                                               \
+  do {                                                                        \
+    QUEUE_NEXT(q) = QUEUE_NEXT(h);                                            \
+    QUEUE_PREV(q) = (h);                                                      \
+    QUEUE_NEXT_PREV(q) = (q);                                                 \
+    QUEUE_NEXT(h) = (q);                                                      \
+  }                                                                           \
+  while (0)
+
+#define QUEUE_INSERT_TAIL(h, q)                                               \
+  do {                                                                        \
+    QUEUE_NEXT(q) = (h);                                                      \
+    QUEUE_PREV(q) = QUEUE_PREV(h);                                            \
+    QUEUE_PREV_NEXT(q) = (q);                                                 \
+    QUEUE_PREV(h) = (q);                                                      \
+  }                                                                           \
+  while (0)
+
+#define QUEUE_REMOVE(q)                                                       \
+  do {                                                                        \
+    QUEUE_PREV_NEXT(q) = QUEUE_NEXT(q);                                       \
+    QUEUE_NEXT_PREV(q) = QUEUE_PREV(q);                                       \
+  }                                                                           \
+  while (0)
+
+#endif /* QUEUE_H_ */

--- a/packages/emnapi/src/thread-safe-function.ts
+++ b/packages/emnapi/src/thread-safe-function.ts
@@ -1,0 +1,76 @@
+mergeInto(LibraryManager.library, {
+  $emnapiAddTSFNListener__deps: ['$emnapiGetDynamicCalls'],
+  $emnapiAddTSFNListener: function (worker: any) {
+    if (!worker._emnapiTSFNListener) {
+      worker._emnapiTSFNListener = function _emnapiTSFNListener (e: any) {
+        const data = ENVIRONMENT_IS_NODE ? e : e.data
+        if (data.emnapiTSFNSend) {
+          emnapiGetDynamicCalls.call_vi(data.emnapiTSFNSend.callback, data.emnapiTSFNSend.data)
+        }
+      }
+      if (ENVIRONMENT_IS_NODE) {
+        worker.on('message', worker._emnapiTSFNListener)
+      } else {
+        worker.addEventListener('message', worker._emnapiTSFNListener, false)
+      }
+    }
+  },
+
+  _emnapi_tsfn_send_js__deps: ['$PThread', '$emnapiGetDynamicCalls', '$emnapiAddTSFNListener'],
+  _emnapi_tsfn_send_js: function (callback: number, data: number): void {
+    if (ENVIRONMENT_IS_PTHREAD) {
+      postMessage({
+        emnapiTSFNSend: {
+          callback,
+          data
+        }
+      })
+    } else {
+      setTimeout(() => {
+        emnapiGetDynamicCalls.call_vi(callback, data)
+      })
+    }
+  },
+  _emnapi_tsfn_send_js__postset:
+    'PThread.unusedWorkers.forEach(emnapiAddTSFNListener);' +
+    'PThread.runningWorkers.forEach(emnapiAddTSFNListener);' +
+    'PThread.unusedWorkers.pop = function () {' +
+      'var r = Array.prototype.pop.apply(this, arguments);' +
+      'emnapiAddTSFNListener(r);' +
+      'return r;' +
+    '};'
+})
+
+function _emnapi_call_into_module (env: napi_env, callback: number, data: number): void {
+  const envObject = emnapi.envStore.get(env)!
+  const scope = envObject.openScope(emnapi.HandleScope)
+  try {
+    envObject.callIntoModule((_envObject) => {
+      emnapiGetDynamicCalls.call_vii(callback, env, data)
+    })
+  } catch (err) {
+    envObject.closeScope(scope)
+    throw err
+  }
+  envObject.closeScope(scope)
+}
+
+function _emnapi_tsfn_dispatch_one_js (env: number, ref: number, call_js_cb: number, context: number, data: number): void {
+  const envObject = emnapi.envStore.get(env)!
+  const reference = emnapi.refStore.get(ref)
+  // eslint-disable-next-line @typescript-eslint/prefer-optional-chain, @typescript-eslint/prefer-nullish-coalescing
+  const jsCallback = (reference && reference.get()) || 0
+  const scope = envObject.openScope(emnapi.HandleScope)
+  try {
+    envObject.callIntoModule((_envObject) => {
+      emnapiGetDynamicCalls.call_viiii(call_js_cb, env, jsCallback, context, data)
+    })
+  } catch (err) {
+    envObject.closeScope(scope)
+    throw err
+  }
+  envObject.closeScope(scope)
+}
+
+emnapiImplement('_emnapi_call_into_module', _emnapi_call_into_module, ['$emnapiGetDynamicCalls'])
+emnapiImplement('_emnapi_tsfn_dispatch_one_js', _emnapi_tsfn_dispatch_one_js, ['$emnapiGetDynamicCalls'])

--- a/packages/emnapi/src/util.ts
+++ b/packages/emnapi/src/util.ts
@@ -30,7 +30,6 @@ declare const typedArrayMemoryMap: WeakMap<TypedArray | DataView, number>
 declare const memoryPointerDeleter: FinalizationRegistry<number>
 
 mergeInto(LibraryManager.library, {
-  $memoryPointerDeleter__deps: ['free'],
   $memoryPointerDeleter: 'typeof FinalizationRegistry === "function" ? new FinalizationRegistry(function (pointer) { _free(pointer); }) : undefined',
   $arrayBufferMemoryMap: 'new WeakMap()',
   $typedArrayMemoryMap: 'new WeakMap()',

--- a/packages/runtime/src/typings/common.d.ts
+++ b/packages/runtime/src/typings/common.d.ts
@@ -1,7 +1,9 @@
 declare interface IDynamicCalls {
   call_vi (_ptr: number, a: int32_t): void
   call_ii (_ptr: number, a: int32_t): int32_t
+  call_vii (_ptr: number, a: int32_t, b: int32_t): void
   call_iii (_ptr: number, a: int32_t, b: int32_t): int32_t
   call_viii (_ptr: number, a: int32_t, b: int32_t, c: int32_t): void
+  call_viiii (_ptr: number, a: int32_t, b: int32_t, c: int32_t, d: int32_t): void
   call_malloc (_source: string, _size: string | number): void_p
 }

--- a/packages/test/cgen.config.js
+++ b/packages/test/cgen.config.js
@@ -76,6 +76,7 @@ module.exports = function (_options, { isDebug, isEmscripten }) {
       createTarget('env', ['./env/binding.c']),
       createTarget('hello', ['./hello/binding.c']),
       createTarget('async', ['./async/binding.c'], false, true),
+      ...(isEmscripten ? [createTarget('tsfn', ['./tsfn/binding.c'], false, true)] : []),
       createTarget('arg', ['./arg/binding.c'], true),
       createTarget('callback', ['./callback/binding.c'], true),
       createTarget('objfac', ['./objfac/binding.c'], true),

--- a/packages/test/tsfn/binding.c
+++ b/packages/test/tsfn/binding.c
@@ -1,0 +1,322 @@
+// For the purpose of this test we use libuv's threading library. When deciding
+// on a threading library for a new project it bears remembering that in the
+// future libuv may introduce API changes which may render it non-ABI-stable,
+// which, in turn, may affect the ABI stability of the project despite its use
+// of N-API.
+#include <emscripten.h>
+#include <pthread.h>
+#include <node_api.h>
+#include "../common.h"
+
+#define ARRAY_LENGTH 10000
+#define MAX_QUEUE_SIZE 2
+
+static pthread_t uv_threads[2];
+static napi_threadsafe_function ts_fn;
+
+typedef struct {
+  napi_threadsafe_function_call_mode block_on_full;
+  napi_threadsafe_function_release_mode abort;
+  bool start_secondary;
+  napi_ref js_finalize_cb;
+  uint32_t max_queue_size;
+} ts_fn_hint;
+
+static ts_fn_hint ts_info;
+
+// Thread data to transmit to JS
+static int ints[ARRAY_LENGTH];
+
+static void* secondary_thread(void* data) {
+  napi_threadsafe_function ts_fn = data;
+
+  if (napi_release_threadsafe_function(ts_fn, napi_tsfn_release) != napi_ok) {
+    napi_fatal_error("secondary_thread", NAPI_AUTO_LENGTH,
+        "napi_release_threadsafe_function failed", NAPI_AUTO_LENGTH);
+  }
+
+  return NULL;
+}
+
+// Source thread producing the data
+static void* data_source_thread(void* data) {
+  napi_threadsafe_function ts_fn = data;
+  int index;
+  void* hint;
+  ts_fn_hint *ts_fn_info;
+  napi_status status;
+  bool queue_was_full = false;
+  bool queue_was_closing = false;
+
+  if (napi_get_threadsafe_function_context(ts_fn, &hint) != napi_ok) {
+    napi_fatal_error("data_source_thread", NAPI_AUTO_LENGTH,
+        "napi_get_threadsafe_function_context failed", NAPI_AUTO_LENGTH);
+  }
+
+  ts_fn_info = (ts_fn_hint *)hint;
+
+  if (ts_fn_info != &ts_info) {
+    napi_fatal_error("data_source_thread", NAPI_AUTO_LENGTH,
+      "thread-safe function hint is not as expected", NAPI_AUTO_LENGTH);
+  }
+
+  if (ts_fn_info->start_secondary) {
+    if (napi_acquire_threadsafe_function(ts_fn) != napi_ok) {
+      napi_fatal_error("data_source_thread", NAPI_AUTO_LENGTH,
+        "napi_acquire_threadsafe_function failed", NAPI_AUTO_LENGTH);
+    }
+
+    if (pthread_create(&uv_threads[1], NULL, secondary_thread, ts_fn) != 0) {
+      napi_fatal_error("data_source_thread", NAPI_AUTO_LENGTH,
+        "failed to start secondary thread", NAPI_AUTO_LENGTH);
+    }
+  }
+
+  for (index = ARRAY_LENGTH - 1; index > -1 && !queue_was_closing; index--) {
+    status = napi_call_threadsafe_function(ts_fn, &ints[index],
+        ts_fn_info->block_on_full);
+    if (ts_fn_info->max_queue_size == 0 && (index % 1000 == 0)) {
+      // Let's make this thread really busy for 200 ms to give the main thread a
+      // chance to abort.
+      double start = emscripten_get_now();
+      for (; emscripten_get_now() - start < (double)200;);
+    }
+    switch (status) {
+      case napi_queue_full:
+        queue_was_full = true;
+        index++;
+        // fall through
+
+      case napi_ok:
+        continue;
+
+      case napi_closing:
+        queue_was_closing = true;
+        break;
+
+      default:
+        napi_fatal_error("data_source_thread", NAPI_AUTO_LENGTH,
+            "napi_call_threadsafe_function failed", NAPI_AUTO_LENGTH);
+    }
+  }
+
+  // Assert that the enqueuing of a value was refused at least once, if this is
+  // a non-blocking test run.
+  if (!ts_fn_info->block_on_full && !queue_was_full) {
+    napi_fatal_error("data_source_thread", NAPI_AUTO_LENGTH,
+        "queue was never full", NAPI_AUTO_LENGTH);
+  }
+
+  // Assert that the queue was marked as closing at least once, if this is an
+  // aborting test run.
+  if (ts_fn_info->abort == napi_tsfn_abort && !queue_was_closing) {
+    napi_fatal_error("data_source_thread", NAPI_AUTO_LENGTH,
+      "queue was never closing", NAPI_AUTO_LENGTH);
+  }
+
+  if (!queue_was_closing &&
+      napi_release_threadsafe_function(ts_fn, napi_tsfn_release) != napi_ok) {
+    napi_fatal_error("data_source_thread", NAPI_AUTO_LENGTH,
+        "napi_release_threadsafe_function failed", NAPI_AUTO_LENGTH);
+  }
+
+  return NULL;
+}
+
+// Getting the data into JS
+static void call_js(napi_env env, napi_value cb, void* hint, void* data) {
+  if (!(env == NULL || cb == NULL)) {
+    napi_value argv, undefined;
+    NAPI_CALL_RETURN_VOID(env, napi_create_int32(env, *(int*)data, &argv));
+    NAPI_CALL_RETURN_VOID(env, napi_get_undefined(env, &undefined));
+    NAPI_CALL_RETURN_VOID(env, napi_call_function(env, undefined, cb, 1, &argv,
+        NULL));
+  }
+}
+
+static napi_ref alt_ref;
+// Getting the data into JS with the alternative reference
+static void call_ref(napi_env env, napi_value _, void* hint, void* data) {
+  if (!(env == NULL || alt_ref == NULL)) {
+    napi_value fn, argv, undefined;
+    NAPI_CALL_RETURN_VOID(env, napi_get_reference_value(env, alt_ref, &fn));
+    NAPI_CALL_RETURN_VOID(env, napi_create_int32(env, *(int*)data, &argv));
+    NAPI_CALL_RETURN_VOID(env, napi_get_undefined(env, &undefined));
+    NAPI_CALL_RETURN_VOID(env, napi_call_function(env, undefined, fn, 1, &argv,
+        NULL));
+  }
+}
+
+// Cleanup
+static napi_value StopThread(napi_env env, napi_callback_info info) {
+  size_t argc = 2;
+  napi_value argv[2];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, argv, NULL, NULL));
+  napi_valuetype value_type;
+  NAPI_CALL(env, napi_typeof(env, argv[0], &value_type));
+  NAPI_ASSERT(env, value_type == napi_function,
+      "StopThread argument is a function");
+  NAPI_ASSERT(env, (ts_fn != NULL), "Existing threadsafe function");
+  NAPI_CALL(env,
+      napi_create_reference(env, argv[0], 1, &(ts_info.js_finalize_cb)));
+  bool abort;
+  NAPI_CALL(env, napi_get_value_bool(env, argv[1], &abort));
+  NAPI_CALL(env,
+      napi_release_threadsafe_function(ts_fn,
+          abort ? napi_tsfn_abort : napi_tsfn_release));
+  ts_fn = NULL;
+  return NULL;
+}
+
+// Join the thread and inform JS that we're done.
+static void join_the_threads(napi_env env, void *data, void *hint) {
+  pthread_t *the_threads = data;
+  ts_fn_hint *the_hint = hint;
+  napi_value js_cb, undefined;
+
+  pthread_join(the_threads[0], NULL);
+  if (the_hint->start_secondary) {
+    pthread_join(the_threads[1], NULL);
+  }
+
+  NAPI_CALL_RETURN_VOID(env,
+      napi_get_reference_value(env, the_hint->js_finalize_cb, &js_cb));
+  NAPI_CALL_RETURN_VOID(env, napi_get_undefined(env, &undefined));
+  NAPI_CALL_RETURN_VOID(env,
+      napi_call_function(env, undefined, js_cb, 0, NULL, NULL));
+  NAPI_CALL_RETURN_VOID(env, napi_delete_reference(env,
+      the_hint->js_finalize_cb));
+  if (alt_ref != NULL) {
+    NAPI_CALL_RETURN_VOID(env, napi_delete_reference(env, alt_ref));
+    alt_ref = NULL;
+  }
+}
+
+static napi_value StartThreadInternal(napi_env env,
+                                      napi_callback_info info,
+                                      napi_threadsafe_function_call_js cb,
+                                      bool block_on_full,
+                                      bool alt_ref_js_cb) {
+
+  size_t argc = 4;
+  napi_value argv[4];
+
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, argv, NULL, NULL));
+  if (alt_ref_js_cb) {
+    NAPI_CALL(env, napi_create_reference(env, argv[0], 1, &alt_ref));
+    argv[0] = NULL;
+  }
+
+  ts_info.block_on_full =
+      (block_on_full ? napi_tsfn_blocking : napi_tsfn_nonblocking);
+
+  NAPI_ASSERT(env, (ts_fn == NULL), "Existing thread-safe function");
+  napi_value async_name;
+  NAPI_CALL(env, napi_create_string_utf8(env,
+      "N-API Thread-safe Function Test", NAPI_AUTO_LENGTH, &async_name));
+  NAPI_CALL(env,
+      napi_get_value_uint32(env, argv[3], &ts_info.max_queue_size));
+  NAPI_CALL(env, napi_create_threadsafe_function(env,
+                                                     argv[0],
+                                                     NULL,
+                                                     async_name,
+                                                     ts_info.max_queue_size,
+                                                     2,
+                                                     uv_threads,
+                                                     join_the_threads,
+                                                     &ts_info,
+                                                     cb,
+                                                     &ts_fn));
+  bool abort;
+  NAPI_CALL(env, napi_get_value_bool(env, argv[1], &abort));
+  ts_info.abort = abort ? napi_tsfn_abort : napi_tsfn_release;
+  NAPI_CALL(env,
+      napi_get_value_bool(env, argv[2], &(ts_info.start_secondary)));
+
+  NAPI_ASSERT(env,
+      (pthread_create(&uv_threads[0], NULL, data_source_thread, ts_fn) == 0),
+      "Thread creation");
+
+  return NULL;
+}
+
+static napi_value Unref(napi_env env, napi_callback_info info) {
+  NAPI_ASSERT(env, ts_fn != NULL, "No existing thread-safe function");
+  NAPI_CALL(env, napi_unref_threadsafe_function(env, ts_fn));
+  return NULL;
+}
+
+static napi_value Release(napi_env env, napi_callback_info info) {
+  NAPI_ASSERT(env, ts_fn != NULL, "No existing thread-safe function");
+  NAPI_CALL(env, napi_release_threadsafe_function(ts_fn, napi_tsfn_release));
+  return NULL;
+}
+
+// Startup
+static napi_value StartThread(napi_env env, napi_callback_info info) {
+  return StartThreadInternal(env, info, call_js,
+    /** block_on_full */true, /** alt_ref_js_cb */false);
+}
+
+static napi_value StartThreadNonblocking(napi_env env,
+                                         napi_callback_info info) {
+  return StartThreadInternal(env, info, call_js,
+    /** block_on_full */false, /** alt_ref_js_cb */false);
+}
+
+static napi_value StartThreadNoNative(napi_env env, napi_callback_info info) {
+  return StartThreadInternal(env, info, NULL,
+    /** block_on_full */true, /** alt_ref_js_cb */false);
+}
+
+static napi_value StartThreadNoJsFunc(napi_env env, napi_callback_info info) {
+  return StartThreadInternal(env, info, call_ref,
+    /** block_on_full */true, /** alt_ref_js_cb */true);
+}
+
+// Module init
+static napi_value Init(napi_env env, napi_value exports) {
+  size_t index;
+  for (index = 0; index < ARRAY_LENGTH; index++) {
+    ints[index] = index;
+  }
+  napi_value js_array_length, js_max_queue_size;
+  napi_create_uint32(env, ARRAY_LENGTH, &js_array_length);
+  napi_create_uint32(env, MAX_QUEUE_SIZE, &js_max_queue_size);
+
+  napi_property_descriptor properties[] = {
+    {
+      "ARRAY_LENGTH",
+      NULL,
+      NULL,
+      NULL,
+      NULL,
+      js_array_length,
+      napi_enumerable,
+      NULL
+    },
+    {
+      "MAX_QUEUE_SIZE",
+      NULL,
+      NULL,
+      NULL,
+      NULL,
+      js_max_queue_size,
+      napi_enumerable,
+      NULL
+    },
+    DECLARE_NAPI_PROPERTY("StartThread", StartThread),
+    DECLARE_NAPI_PROPERTY("StartThreadNoNative", StartThreadNoNative),
+    DECLARE_NAPI_PROPERTY("StartThreadNonblocking", StartThreadNonblocking),
+    DECLARE_NAPI_PROPERTY("StartThreadNoJsFunc", StartThreadNoJsFunc),
+    DECLARE_NAPI_PROPERTY("StopThread", StopThread),
+    DECLARE_NAPI_PROPERTY("Unref", Unref),
+    DECLARE_NAPI_PROPERTY("Release", Release),
+  };
+
+  NAPI_CALL(env, napi_define_properties(env, exports,
+    sizeof(properties)/sizeof(properties[0]), properties));
+
+  return exports;
+}
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/packages/test/tsfn/tsfn.test.js
+++ b/packages/test/tsfn/tsfn.test.js
@@ -1,0 +1,235 @@
+/* eslint-disable camelcase */
+'use strict'
+const { load } = require('../util')
+const common = require('../common')
+const assert = require('assert')
+// const { fork } = require('child_process')
+
+async function main () {
+  const loadPromise = load('tsfn')
+  const binding = await loadPromise
+
+  const expectedArray = (function (arrayLength) {
+    const result = []
+    for (let index = 0; index < arrayLength; index++) {
+      result.push(arrayLength - 1 - index)
+    }
+    return result
+  })(binding.ARRAY_LENGTH)
+
+  // Handle the rapid teardown test case as the child process. We unref the
+  // thread-safe function after we have received two values. This causes the
+  // process to exit and the environment cleanup handler to be invoked.
+  if (process.argv[2] === 'child') {
+    let callCount = 0
+    binding.StartThread((value) => {
+      callCount++
+      console.log(value)
+      if (callCount === 2) {
+        binding.Unref()
+      }
+    }, false /* abort */, true /* launchSecondary */, +process.argv[3])
+
+    // Release the thread-safe function from the main thread so that it may be
+    // torn down via the environment cleanup handler.
+    binding.Release()
+  }
+
+  function testWithJSMarshaller ({
+    threadStarter,
+    quitAfter,
+    abort,
+    maxQueueSize,
+    launchSecondary
+  }) {
+    return new Promise((resolve) => {
+      const array = []
+      binding[threadStarter](function testCallback (value) {
+        array.push(value)
+        if (array.length === quitAfter) {
+          setImmediate(() => {
+            binding.StopThread(common.mustCall(() => {
+              resolve(array)
+            }), !!abort)
+          })
+        }
+      }, !!abort, !!launchSecondary, maxQueueSize)
+      if (threadStarter === 'StartThreadNonblocking') {
+        // Let's make this thread really busy for a short while to ensure that
+        // the queue fills and the thread receives a napi_queue_full.
+        const start = Date.now()
+        while (Date.now() - start < 200);
+      }
+    })
+  }
+
+  // function testUnref (queueSize) {
+  //   return new Promise((resolve, reject) => {
+  //     let output = ''
+  //     const child = fork(__filename, ['child', queueSize], {
+  //       stdio: [process.stdin, 'pipe', process.stderr, 'ipc']
+  //     })
+  //     child.on('close', (code) => {
+  //       if (code === 0) {
+  //         resolve(output.match(/\S+/g))
+  //       } else {
+  //         reject(new Error('Child process died with code ' + code))
+  //       }
+  //     })
+  //     child.stdout.on('data', (data) => (output += data.toString()))
+  //   })
+  //     .then((result) => assert.strictEqual(result.indexOf(0), -1))
+  // }
+
+  // eslint-disable-next-line no-new
+  await new Promise(function testWithoutJSMarshaller (resolve) {
+    let callCount = 0
+    binding.StartThreadNoNative(function testCallback () {
+      callCount++
+
+      // The default call-into-JS implementation passes no arguments.
+      assert.strictEqual(arguments.length, 0)
+      if (callCount === binding.ARRAY_LENGTH) {
+        setImmediate(() => {
+          binding.StopThread(common.mustCall(() => {
+            resolve()
+          }), false)
+        })
+      }
+    }, false /* abort */, false /* launchSecondary */, binding.MAX_QUEUE_SIZE)
+  })
+
+    // Start the thread in blocking mode, and assert that all values are passed.
+    // Quit after it's done.
+    .then(() => testWithJSMarshaller({
+      threadStarter: 'StartThread',
+      maxQueueSize: binding.MAX_QUEUE_SIZE,
+      quitAfter: binding.ARRAY_LENGTH
+    }))
+    .then((result) => assert.deepStrictEqual(result, expectedArray))
+
+    // Start the thread in blocking mode, and assert that all values are passed.
+    // Quit after it's done.
+    // Doesn't pass the callback js function to napi_create_threadsafe_function.
+    // Instead, use an alternative reference to get js function called.
+    .then(() => testWithJSMarshaller({
+      threadStarter: 'StartThreadNoJsFunc',
+      maxQueueSize: binding.MAX_QUEUE_SIZE,
+      quitAfter: binding.ARRAY_LENGTH
+    }))
+    .then((result) => assert.deepStrictEqual(result, expectedArray))
+
+    // Start the thread in blocking mode with an infinite queue, and assert that all
+    // values are passed. Quit after it's done.
+    .then(() => testWithJSMarshaller({
+      threadStarter: 'StartThread',
+      maxQueueSize: 0,
+      quitAfter: binding.ARRAY_LENGTH
+    }))
+    .then((result) => assert.deepStrictEqual(result, expectedArray))
+
+    // Start the thread in non-blocking mode, and assert that all values are passed.
+    // Quit after it's done.
+    .then(() => testWithJSMarshaller({
+      threadStarter: 'StartThreadNonblocking',
+      maxQueueSize: binding.MAX_QUEUE_SIZE,
+      quitAfter: binding.ARRAY_LENGTH
+    }))
+    .then((result) => assert.deepStrictEqual(result, expectedArray))
+
+    // Start the thread in blocking mode, and assert that all values are passed.
+    // Quit early, but let the thread finish.
+    .then(() => testWithJSMarshaller({
+      threadStarter: 'StartThread',
+      maxQueueSize: binding.MAX_QUEUE_SIZE,
+      quitAfter: 1
+    }))
+    .then((result) => assert.deepStrictEqual(result, expectedArray))
+
+    // Start the thread in blocking mode with an infinite queue, and assert that all
+    // values are passed. Quit early, but let the thread finish.
+    .then(() => testWithJSMarshaller({
+      threadStarter: 'StartThread',
+      maxQueueSize: 0,
+      quitAfter: 1
+    }))
+    .then((result) => assert.deepStrictEqual(result, expectedArray))
+
+    // Start the thread in non-blocking mode, and assert that all values are passed.
+    // Quit early, but let the thread finish.
+    .then(() => testWithJSMarshaller({
+      threadStarter: 'StartThreadNonblocking',
+      maxQueueSize: binding.MAX_QUEUE_SIZE,
+      quitAfter: 1
+    }))
+    .then((result) => assert.deepStrictEqual(result, expectedArray))
+
+    // Start the thread in blocking mode, and assert that all values are passed.
+    // Quit early, but let the thread finish. Launch a secondary thread to test the
+    // reference counter incrementing functionality.
+    .then(() => testWithJSMarshaller({
+      threadStarter: 'StartThread',
+      quitAfter: 1,
+      maxQueueSize: binding.MAX_QUEUE_SIZE,
+      launchSecondary: true
+    }))
+    .then((result) => assert.deepStrictEqual(result, expectedArray))
+
+    // Start the thread in non-blocking mode, and assert that all values are passed.
+    // Quit early, but let the thread finish. Launch a secondary thread to test the
+    // reference counter incrementing functionality.
+    .then(() => testWithJSMarshaller({
+      threadStarter: 'StartThreadNonblocking',
+      quitAfter: 1,
+      maxQueueSize: binding.MAX_QUEUE_SIZE,
+      launchSecondary: true
+    }))
+    .then((result) => assert.deepStrictEqual(result, expectedArray))
+
+    // Start the thread in blocking mode, and assert that it could not finish.
+    // Quit early by aborting.
+    .then(() => testWithJSMarshaller({
+      threadStarter: 'StartThread',
+      quitAfter: 1,
+      maxQueueSize: binding.MAX_QUEUE_SIZE,
+      abort: true
+    }))
+    .then((result) => assert.strictEqual(result.indexOf(0), -1))
+
+    // Start the thread in blocking mode with an infinite queue, and assert that it
+    // could not finish. Quit early by aborting.
+    .then(() => testWithJSMarshaller({
+      threadStarter: 'StartThread',
+      quitAfter: 1,
+      maxQueueSize: 0,
+      abort: true
+    }))
+    .then((result) => assert.strictEqual(result.indexOf(0), -1))
+
+    // Start the thread in non-blocking mode, and assert that it could not finish.
+    // Quit early and aborting.
+    .then(() => testWithJSMarshaller({
+      threadStarter: 'StartThreadNonblocking',
+      quitAfter: 1,
+      maxQueueSize: binding.MAX_QUEUE_SIZE,
+      abort: true
+    }))
+    .then((result) => assert.strictEqual(result.indexOf(0), -1))
+
+    // Make sure that threadsafe function isn't stalled when we hit
+    // `kMaxIterationCount` in `src/node_api.cc`
+    .then(() => testWithJSMarshaller({
+      threadStarter: 'StartThreadNonblocking',
+      maxQueueSize: binding.ARRAY_LENGTH >>> 1,
+      quitAfter: binding.ARRAY_LENGTH
+    }))
+    .then((result) => assert.deepStrictEqual(result, expectedArray))
+
+  // Start a child process to test rapid teardown
+  // .then(() => testUnref(binding.MAX_QUEUE_SIZE))
+
+  // Start a child process with an infinite queue to test rapid teardown
+  // .then(() => testUnref(0))
+}
+
+module.exports = main()

--- a/script/release.js
+++ b/script/release.js
@@ -16,6 +16,7 @@ fs.copyFileSync(path.join(__dirname, '../packages/runtime/dist/emnapi.js'), path
 fs.copyFileSync(path.join(__dirname, '../packages/runtime/dist/emnapi.min.js'), path.join(root, 'lib', 'emnapi.min.js'))
 // fs.copyFileSync(path.join(__dirname, '../packages/runtime/dist/emnapi.d.ts'), path.join(root, 'lib', 'emnapi.d.ts'))
 fs.copyFileSync(path.join(__dirname, '../packages/emnapi/src/emnapi.c'), path.join(root, 'src', 'emnapi.c'))
+fs.copyFileSync(path.join(__dirname, '../packages/emnapi/src/queue.h'), path.join(root, 'src', 'queue.h'))
 fs.readdirSync(path.join(__dirname, '../packages/emnapi/include')).forEach(item => {
   if (item !== '.' && item !== '..') {
     fs.copyFileSync(path.join(__dirname, '../packages/emnapi/include', item), path.join(root, 'include/emnapi', item))


### PR DESCRIPTION
This PR implement [asynchronous thread-safe function calls](https://nodejs.org/dist/latest-v16.x/docs/api/n-api.html#asynchronous-thread-safe-function-calls)

- [napi_create_threadsafe_function](https://nodejs.org/dist/latest-v16.x/docs/api/n-api.html#napi_create_threadsafe_function) (`async_resource` and `async_resource_name` parameter have no effect)
- [napi_get_threadsafe_function_context](https://nodejs.org/dist/latest-v16.x/docs/api/n-api.html#napi_get_threadsafe_function_context)
- [napi_call_threadsafe_function](https://nodejs.org/dist/latest-v16.x/docs/api/n-api.html#napi_call_threadsafe_function)
- [napi_acquire_threadsafe_function](https://nodejs.org/dist/latest-v16.x/docs/api/n-api.html#napi_acquire_threadsafe_function)
- [napi_release_threadsafe_function](https://nodejs.org/dist/latest-v16.x/docs/api/n-api.html#napi_release_threadsafe_function)
- [napi_ref_threadsafe_function](https://nodejs.org/dist/latest-v16.x/docs/api/n-api.html#napi_ref_threadsafe_function) (No effect, always return `napi_ok` if using `-sUSE_PTHREADS=1`)
- [napi_unref_threadsafe_function](https://nodejs.org/dist/latest-v16.x/docs/api/n-api.html#napi_unref_threadsafe_function) (No effect, Always return `napi_ok` if using `-sUSE_PTHREADS=1`)

The implementation depends Emscripten pthread support, require `-sUSE_PTHREADS=1`
