### PR TITLE
feat: emnapi_create_memory_view

### DIFF
--- a/packages/emnapi/include/emnapi.h
+++ b/packages/emnapi/include/emnapi.h
@@ -15,6 +15,22 @@ typedef enum {
   emnapi_userland,
 } emnapi_ownership;
 
+typedef enum {
+  emnapi_int8_array,
+  emnapi_uint8_array,
+  emnapi_uint8_clamped_array,
+  emnapi_int16_array,
+  emnapi_uint16_array,
+  emnapi_int32_array,
+  emnapi_uint32_array,
+  emnapi_float32_array,
+  emnapi_float64_array,
+  emnapi_bigint64_array,
+  emnapi_biguint64_array,
+  emnapi_data_view = 16,
+  emnapi_buffer = 17,
+} emnapi_memory_view_type;
+
 EXTERN_C_START
 
 NAPI_EXTERN int emnapi_is_support_weakref();
@@ -31,7 +47,7 @@ napi_status emnapi_get_module_property(napi_env env,
 
 NAPI_EXTERN
 napi_status emnapi_create_memory_view(napi_env env,
-                                      napi_typedarray_type type,
+                                      emnapi_memory_view_type type,
                                       void* external_data,
                                       size_t byte_length,
                                       napi_finalize finalize_cb,

--- a/packages/emnapi/include/emnapi.h
+++ b/packages/emnapi/include/emnapi.h
@@ -45,11 +45,9 @@ napi_status emnapi_get_emscripten_version(napi_env env,
 NAPI_EXTERN
 napi_status emnapi_sync_memory(napi_env env,
                                bool js_to_wasm,
-                               napi_value arraybuffer_or_view,
+                               napi_value* arraybuffer_or_view,
                                size_t byte_offset,
-                               void* data,
-                               size_t length,
-                               napi_value* result);
+                               size_t length);
 
 NAPI_EXTERN
 napi_status emnapi_get_memory_address(napi_env env,

--- a/packages/emnapi/include/emnapi.h
+++ b/packages/emnapi/include/emnapi.h
@@ -29,15 +29,13 @@ napi_status emnapi_get_module_property(napi_env env,
                                        const char* utf8name,
                                        napi_value* result);
 
-#ifndef NODE_API_NO_EXTERNAL_BUFFERS_ALLOWED
 NAPI_EXTERN
-napi_status emnapi_create_external_uint8array(napi_env env,
-                                              void* external_data,
-                                              size_t byte_length,
-                                              napi_finalize finalize_cb,
-                                              void* finalize_hint,
-                                              napi_value* result);
-#endif
+napi_status emnapi_create_memory_view(napi_env env,
+                                      void* external_data,
+                                      size_t byte_length,
+                                      napi_finalize finalize_cb,
+                                      void* finalize_hint,
+                                      napi_value* result);
 
 NAPI_EXTERN
 napi_status emnapi_get_emscripten_version(napi_env env,

--- a/packages/emnapi/include/emnapi.h
+++ b/packages/emnapi/include/emnapi.h
@@ -27,8 +27,8 @@ typedef enum {
   emnapi_float64_array,
   emnapi_bigint64_array,
   emnapi_biguint64_array,
-  emnapi_data_view = 16,
-  emnapi_buffer = 17,
+  emnapi_data_view = -1,
+  emnapi_buffer = -2,
 } emnapi_memory_view_type;
 
 EXTERN_C_START

--- a/packages/emnapi/include/emnapi.h
+++ b/packages/emnapi/include/emnapi.h
@@ -31,6 +31,7 @@ napi_status emnapi_get_module_property(napi_env env,
 
 NAPI_EXTERN
 napi_status emnapi_create_memory_view(napi_env env,
+                                      napi_typedarray_type type,
                                       void* external_data,
                                       size_t byte_length,
                                       napi_finalize finalize_cb,
@@ -47,7 +48,8 @@ napi_status emnapi_sync_memory(napi_env env,
                                size_t byte_offset,
                                void* data,
                                size_t length,
-                               bool js_to_wasm);
+                               bool js_to_wasm,
+                               napi_value* result);
 
 NAPI_EXTERN
 napi_status emnapi_get_memory_address(napi_env env,

--- a/packages/emnapi/include/emnapi.h
+++ b/packages/emnapi/include/emnapi.h
@@ -44,11 +44,11 @@ napi_status emnapi_get_emscripten_version(napi_env env,
 
 NAPI_EXTERN
 napi_status emnapi_sync_memory(napi_env env,
+                               bool js_to_wasm,
                                napi_value arraybuffer_or_view,
                                size_t byte_offset,
                                void* data,
                                size_t length,
-                               bool js_to_wasm,
                                napi_value* result);
 
 NAPI_EXTERN

--- a/packages/emnapi/include/node_api.h
+++ b/packages/emnapi/include/node_api.h
@@ -73,6 +73,41 @@ NAPI_EXTERN NAPI_NO_RETURN void napi_fatal_error(const char* location,
                                                  const char* message,
                                                  size_t message_len);
 
+// Methods to provide node::Buffer functionality with napi types
+NAPI_EXTERN napi_status
+napi_create_buffer(napi_env env,
+                   size_t length,
+                   void** data,
+                   napi_value* result);
+
+#ifndef NODE_API_NO_EXTERNAL_BUFFERS_ALLOWED
+NAPI_EXTERN napi_status
+napi_create_external_buffer(napi_env env,
+                            size_t length,
+                            void* data,
+                            napi_finalize finalize_cb,
+                            void* finalize_hint,
+                            napi_value* result);
+#endif  // NODE_API_NO_EXTERNAL_BUFFERS_ALLOWED
+
+NAPI_EXTERN napi_status
+napi_create_buffer_copy(napi_env env,
+                        size_t length,
+                        const void* data,
+                        void** result_data,
+                        napi_value* result);
+
+NAPI_EXTERN napi_status
+napi_is_buffer(napi_env env,
+               napi_value value,
+               bool* result);
+
+NAPI_EXTERN napi_status
+napi_get_buffer_info(napi_env env,
+                     napi_value value,
+                     void** data,
+                     size_t* length);
+
 NAPI_EXTERN
 napi_status napi_get_node_version(napi_env env,
                                   const napi_node_version** version);
@@ -124,41 +159,6 @@ NAPI_EXTERN napi_status
 napi_ref_threadsafe_function(napi_env env, napi_threadsafe_function func);
 
 #endif
-
-// Methods to provide node::Buffer functionality with napi types
-NAPI_EXTERN napi_status
-napi_create_buffer(napi_env env,
-                   size_t length,
-                   void** data,
-                   napi_value* result);
-
-#ifndef NODE_API_NO_EXTERNAL_BUFFERS_ALLOWED
-NAPI_EXTERN napi_status
-napi_create_external_buffer(napi_env env,
-                            size_t length,
-                            void* data,
-                            napi_finalize finalize_cb,
-                            void* finalize_hint,
-                            napi_value* result);
-#endif  // NODE_API_NO_EXTERNAL_BUFFERS_ALLOWED
-
-NAPI_EXTERN napi_status
-napi_create_buffer_copy(napi_env env,
-                        size_t length,
-                        const void* data,
-                        void** result_data,
-                        napi_value* result);
-
-NAPI_EXTERN napi_status
-napi_is_buffer(napi_env env,
-               napi_value value,
-               bool* result);
-
-NAPI_EXTERN napi_status
-napi_get_buffer_info(napi_env env,
-                     napi_value value,
-                     void** data,
-                     size_t* length);
 
 #endif
 

--- a/packages/emnapi/src/emnapi.ts
+++ b/packages/emnapi/src/emnapi.ts
@@ -199,7 +199,6 @@ function emnapi_sync_memory (env: napi_env, js_to_wasm: bool, arraybuffer_or_vie
 
   $PREAMBLE!(env, (envObject) => {
     $CHECK_ARG!(envObject, arraybuffer_or_view)
-    $CHECK_ARG!(envObject, pointer)
 
     $from64('offset')
     $from64('pointer')

--- a/packages/emnapi/src/emnapi.ts
+++ b/packages/emnapi/src/emnapi.ts
@@ -32,6 +32,8 @@ function emnapi_get_module_property (env: napi_env, utf8name: const_char_p, resu
   })
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+declare const _emnapi_create_memory_view: typeof emnapi_create_memory_view
 function emnapi_create_memory_view (
   env: napi_env,
   typedarray_type: napi_typedarray_type,

--- a/packages/emnapi/src/emnapi.ts
+++ b/packages/emnapi/src/emnapi.ts
@@ -162,6 +162,7 @@ mergeInto(LibraryManager.library, {
         len = arrayBufferOrView.byteLength - offset
       }
       len = len >>> 0
+      if (len === 0) return arrayBufferOrView
       view = new Uint8Array(arrayBufferOrView, offset, len)
 
       if (!js_to_wasm) {
@@ -182,6 +183,7 @@ mergeInto(LibraryManager.library, {
         len = latestView.byteLength - offset
       }
       len = len >>> 0
+      if (len === 0) return latestView
       view = new Uint8Array(latestView.buffer, latestView.byteOffset + offset, len)
 
       if (!js_to_wasm) {

--- a/packages/emnapi/src/emnapi.ts
+++ b/packages/emnapi/src/emnapi.ts
@@ -105,7 +105,7 @@ function emnapi_create_memory_view (
         info = { Ctor: BigUint64Array, ptr: external_data, length: byte_length >> 3 }
         break
       case emnapi_memory_view_type.emnapi_data_view:
-        info = { Ctor: DataView, ptr: external_data, length: byte_length >> 3 }
+        info = { Ctor: DataView, ptr: external_data, length: byte_length }
         break
       case emnapi_memory_view_type.emnapi_buffer:
         info = { Ctor: Buffer, ptr: external_data, length: byte_length }

--- a/packages/emnapi/src/emnapi.ts
+++ b/packages/emnapi/src/emnapi.ts
@@ -69,55 +69,55 @@ function emnapi_create_memory_view (
       throw new emnapiRt.NotSupportWeakRefError('emnapi_create_memory_view', 'Parameter "finalize_cb" must be 0(NULL)')
     }
 
-    let info: ViewInfo
+    let viewDescriptor: MemoryViewDescriptor
     switch (typedarray_type) {
       case emnapi_memory_view_type.emnapi_int8_array:
-        info = { Ctor: Int8Array, ptr: external_data, length: byte_length }
+        viewDescriptor = { Ctor: Int8Array, address: external_data, length: byte_length, ownership: 1, runtimeAllocated: 0 }
         break
       case emnapi_memory_view_type.emnapi_uint8_array:
-        info = { Ctor: Uint8Array, ptr: external_data, length: byte_length }
+        viewDescriptor = { Ctor: Uint8Array, address: external_data, length: byte_length, ownership: 1, runtimeAllocated: 0 }
         break
       case emnapi_memory_view_type.emnapi_uint8_clamped_array:
-        info = { Ctor: Uint8ClampedArray, ptr: external_data, length: byte_length }
+        viewDescriptor = { Ctor: Uint8ClampedArray, address: external_data, length: byte_length, ownership: 1, runtimeAllocated: 0 }
         break
       case emnapi_memory_view_type.emnapi_int16_array:
-        info = { Ctor: Int16Array, ptr: external_data, length: byte_length >> 1 }
+        viewDescriptor = { Ctor: Int16Array, address: external_data, length: byte_length >> 1, ownership: 1, runtimeAllocated: 0 }
         break
       case emnapi_memory_view_type.emnapi_uint16_array:
-        info = { Ctor: Uint16Array, ptr: external_data, length: byte_length >> 1 }
+        viewDescriptor = { Ctor: Uint16Array, address: external_data, length: byte_length >> 1, ownership: 1, runtimeAllocated: 0 }
         break
       case emnapi_memory_view_type.emnapi_int32_array:
-        info = { Ctor: Int32Array, ptr: external_data, length: byte_length >> 2 }
+        viewDescriptor = { Ctor: Int32Array, address: external_data, length: byte_length >> 2, ownership: 1, runtimeAllocated: 0 }
         break
       case emnapi_memory_view_type.emnapi_uint32_array:
-        info = { Ctor: Uint32Array, ptr: external_data, length: byte_length >> 2 }
+        viewDescriptor = { Ctor: Uint32Array, address: external_data, length: byte_length >> 2, ownership: 1, runtimeAllocated: 0 }
         break
       case emnapi_memory_view_type.emnapi_float32_array:
-        info = { Ctor: Float32Array, ptr: external_data, length: byte_length >> 2 }
+        viewDescriptor = { Ctor: Float32Array, address: external_data, length: byte_length >> 2, ownership: 1, runtimeAllocated: 0 }
         break
       case emnapi_memory_view_type.emnapi_float64_array:
-        info = { Ctor: Float64Array, ptr: external_data, length: byte_length >> 3 }
+        viewDescriptor = { Ctor: Float64Array, address: external_data, length: byte_length >> 3, ownership: 1, runtimeAllocated: 0 }
         break
       case emnapi_memory_view_type.emnapi_bigint64_array:
-        info = { Ctor: BigInt64Array, ptr: external_data, length: byte_length >> 3 }
+        viewDescriptor = { Ctor: BigInt64Array, address: external_data, length: byte_length >> 3, ownership: 1, runtimeAllocated: 0 }
         break
       case emnapi_memory_view_type.emnapi_biguint64_array:
-        info = { Ctor: BigUint64Array, ptr: external_data, length: byte_length >> 3 }
+        viewDescriptor = { Ctor: BigUint64Array, address: external_data, length: byte_length >> 3, ownership: 1, runtimeAllocated: 0 }
         break
       case emnapi_memory_view_type.emnapi_data_view:
-        info = { Ctor: DataView, ptr: external_data, length: byte_length }
+        viewDescriptor = { Ctor: DataView, address: external_data, length: byte_length, ownership: 1, runtimeAllocated: 0 }
         break
       case emnapi_memory_view_type.emnapi_buffer:
-        info = { Ctor: Buffer, ptr: external_data, length: byte_length }
+        viewDescriptor = { Ctor: Buffer, address: external_data, length: byte_length, ownership: 1, runtimeAllocated: 0 }
         break
       default: return envObject.setLastError(napi_status.napi_invalid_arg)
     }
-    const Ctor = info.Ctor
+    const Ctor = viewDescriptor.Ctor
     const typedArray = typedarray_type === emnapi_memory_view_type.emnapi_buffer
-      ? Buffer.from(HEAPU8.buffer, info.ptr, info.length)
-      : new Ctor(HEAPU8.buffer, info.ptr, info.length)
+      ? Buffer.from(HEAPU8.buffer, viewDescriptor.address, viewDescriptor.length)
+      : new Ctor(HEAPU8.buffer, viewDescriptor.address, viewDescriptor.length)
     const handle = emnapiCtx.addToCurrentScope(typedArray)
-    emnapiExternalMemory.wasmMemoryViewTable.set(typedArray, info)
+    emnapiExternalMemory.wasmMemoryViewTable.set(typedArray, viewDescriptor)
     if (finalize_cb) {
       const status = emnapiWrap(WrapType.anonymous, env, handle.id, external_data, finalize_cb, finalize_hint, /* NULL */ 0)
       if (status === napi_status.napi_pending_exception) {

--- a/packages/emnapi/src/emnapi.ts
+++ b/packages/emnapi/src/emnapi.ts
@@ -134,20 +134,16 @@ function emnapi_is_support_bigint (): int {
 }
 
 declare function emnapiSyncMemory<T extends ArrayBuffer | ArrayBufferView> (
+  js_to_wasm: boolean,
   arrayBufferOrView: T,
   offset?: number,
   pointer?: number,
   len?: int,
-  js_to_wasm?: boolean
 ): T
 
 mergeInto(LibraryManager.library, {
   $emnapiSyncMemory__deps: ['$emnapiExternalMemory'],
-  $emnapiSyncMemory: function<T extends ArrayBuffer | ArrayBufferView> (arrayBufferOrView: T, offset?: number, pointer?: number, len?: int, js_to_wasm?: boolean): T {
-    if (js_to_wasm === undefined) {
-      // make the usage of this function in js can omit parameters behind the first
-      js_to_wasm = true
-    }
+  $emnapiSyncMemory: function<T extends ArrayBuffer | ArrayBufferView> (js_to_wasm: boolean, arrayBufferOrView: T, offset?: number, pointer?: number, len?: int): T {
     offset = offset ?? 0
     offset = offset >>> 0
     let view: Uint8Array
@@ -197,7 +193,7 @@ mergeInto(LibraryManager.library, {
 })
 
 // @ts-expect-error
-function emnapi_sync_memory (env: napi_env, arraybuffer_or_view: napi_value, offset: size_t, pointer: void_p, len: size_t, js_to_wasm: bool, result: Pointer<napi_value>): napi_status {
+function emnapi_sync_memory (env: napi_env, js_to_wasm: bool, arraybuffer_or_view: napi_value, offset: size_t, pointer: void_p, len: size_t, result: Pointer<napi_value>): napi_status {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let v: number
 
@@ -213,7 +209,7 @@ function emnapi_sync_memory (env: napi_env, arraybuffer_or_view: napi_value, off
     if (!handle.isArrayBuffer() && !handle.isTypedArray() && !handle.isDataView()) {
       return envObject.setLastError(napi_status.napi_invalid_arg)
     }
-    const ret = emnapiSyncMemory(handle.value, offset, pointer, len, Boolean(js_to_wasm))
+    const ret = emnapiSyncMemory(Boolean(js_to_wasm), handle.value, offset, pointer, len)
     if (result) {
       $from64('result')
       v = envObject.ensureHandleId(ret)

--- a/packages/emnapi/src/internal.ts
+++ b/packages/emnapi/src/internal.ts
@@ -105,7 +105,7 @@ function _$emnapiWrap (type: WrapType, env: napi_env, js_object: napi_value, nat
       return envObject.setLastError(napi_status.napi_invalid_arg)
     }
 
-    if (ArrayBuffer.isView(handle.value)) {
+    if (typeof emnapiExternalMemory !== 'undefined' && ArrayBuffer.isView(handle.value)) {
       if (emnapiExternalMemory.wasmMemoryViewTable.has(handle.value)) {
         handle = emnapiCtx.addToCurrentScope(emnapiExternalMemory.wasmMemoryViewTable.get(handle.value)!)
       }
@@ -178,5 +178,5 @@ function _$emnapiUnwrap (env: napi_env, js_object: napi_value, result: void_pp, 
 
 emnapiImplement('$emnapiCreateFunction', undefined, _$emnapiCreateFunction, ['$emnapiUtf8ToString'])
 emnapiImplement('$emnapiDefineProperty', undefined, _$emnapiDefineProperty, ['$emnapiCreateFunction'])
-emnapiImplement('$emnapiWrap', undefined, _$emnapiWrap, ['$emnapiExternalMemory'])
+emnapiImplement('$emnapiWrap', undefined, _$emnapiWrap)
 emnapiImplement('$emnapiUnwrap', undefined, _$emnapiUnwrap)

--- a/packages/emnapi/src/typings/runtime.d.ts
+++ b/packages/emnapi/src/typings/runtime.d.ts
@@ -50,6 +50,20 @@ declare interface ICallbackInfo {
   _isConstructCall: boolean
 }
 
+declare interface Buffer extends Uint8Array {}
+declare interface BufferConstructor {
+  readonly prototype: Buffer
+  /** @deprecated */
+  new (...args: any[]): Buffer
+  from: {
+    (buffer: ArrayBufferLike): Buffer
+    (buffer: ArrayBufferLike, byteOffset: number, length: number): Buffer
+  }
+  alloc: (size: number) => Buffer
+}
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+declare const Buffer: BufferConstructor
+
 /* declare class FinalizationRegistry<H = any> {
   constructor (callback: (heldValue: H) => void)
   register (obj: object, heldValue: H, unregisterToken?: object): void

--- a/packages/emnapi/src/value/convert2c.ts
+++ b/packages/emnapi/src/value/convert2c.ts
@@ -9,7 +9,8 @@ declare type TypedArrayConstructor =
   BigInt64ArrayConstructor |
   BigUint64ArrayConstructor |
   Float32ArrayConstructor |
-  Float64ArrayConstructor
+  Float64ArrayConstructor |
+  DataViewConstructor
 
 declare interface ViewInfo {
   Ctor: TypedArrayConstructor

--- a/packages/emnapi/src/value/convert2c.ts
+++ b/packages/emnapi/src/value/convert2c.ts
@@ -86,6 +86,9 @@ mergeInto(LibraryManager.library, {
             Ctor: view.constructor as any,
             ptr: view.byteOffset,
             length: ((view) => {
+              if (typeof Buffer !== 'undefined' && view.constructor === Buffer) {
+                return view.byteLength
+              }
               switch (view.constructor) {
                 case Int8Array:
                 case Uint8Array:

--- a/packages/emnapi/src/value/convert2c.ts
+++ b/packages/emnapi/src/value/convert2c.ts
@@ -119,7 +119,13 @@ mergeInto(LibraryManager.library, {
 
       if (isDetachedArrayBuffer(view.buffer) && emnapiExternalMemory.wasmMemoryViewTable.has(view)) {
         const info = emnapiExternalMemory.wasmMemoryViewTable.get(view)!
-        const newView = new (info.Ctor)(HEAPU8.buffer, info.ptr, info.length)
+        const Ctor = info.Ctor
+        let newView: ArrayBufferView
+        if (typeof Buffer !== 'undefined' && Ctor === Buffer) {
+          newView = Buffer.from(HEAPU8.buffer, info.ptr, info.length)
+        } else {
+          newView = new Ctor(HEAPU8.buffer, info.ptr, info.length)
+        }
         emnapiExternalMemory.wasmMemoryViewTable.set(newView, info)
         return newView as unknown as T
       }

--- a/packages/emnapi/src/value/convert2c.ts
+++ b/packages/emnapi/src/value/convert2c.ts
@@ -79,30 +79,7 @@ mergeInto(LibraryManager.library, {
           emnapiExternalMemory.wasmMemoryViewTable.set(view, {
             Ctor: view.constructor as any,
             address: view.byteOffset,
-            length: ((view) => {
-              if (typeof Buffer !== 'undefined' && view instanceof Buffer) {
-                return view.byteLength
-              }
-              switch (view.constructor) {
-                case Int8Array:
-                case Uint8Array:
-                case Uint8ClampedArray:
-                case DataView:
-                  return view.byteLength
-                case Int16Array:
-                case Uint16Array:
-                  return view.byteLength >> 1
-                case Int32Array:
-                case Uint32Array:
-                case Float32Array:
-                  return view.byteLength >> 2
-                case Float64Array:
-                case BigInt64Array:
-                case BigUint64Array:
-                  return view.byteLength >> 3
-                default: throw new TypeError('Unknown view type')
-              }
-            })(view),
+            length: view instanceof DataView ? view.byteLength : (view as any).length,
             ownership: 1 /* emnapi.Ownership.kUserland */,
             runtimeAllocated: 0
           })

--- a/packages/emnapi/src/value/create.ts
+++ b/packages/emnapi/src/value/create.ts
@@ -328,30 +328,16 @@ function napi_create_external_buffer (
   finalize_cb: napi_finalize,
   finalize_hint: Pointer<void>,
   result: Pointer<napi_value>
-// @ts-expect-error
 ): napi_status {
-  $PREAMBLE!(env, (envObject) => {
-    const status = _emnapi_create_memory_view(
-      env,
-      napi_typedarray_type.napi_uint8_array,
-      data,
-      length,
-      finalize_cb,
-      finalize_hint,
-      result
-    )
-    if (status !== napi_status.napi_ok) {
-      return status
-    }
-    const handleId = $makeGetValue('result', 0, '*')
-    const handle = emnapiCtx.handleStore.get(handleId)!
-    const info = emnapiExternalMemory.wasmMemoryViewTable.get(handle.value)!
-    const buffer = Buffer.from(HEAPU8.buffer, info.ptr, info.length)
-    emnapiExternalMemory.wasmMemoryViewTable.set(buffer, info)
-    // I know I'm the only owner of handle, so just wrap value in-place.
-    handle.value = buffer
-    return envObject.getReturnStatus()
-  })
+  return _emnapi_create_memory_view(
+    env,
+    emnapi_memory_view_type.emnapi_buffer,
+    data,
+    length,
+    finalize_cb,
+    finalize_hint,
+    result
+  )
 }
 
 function napi_create_dataview (

--- a/packages/emnapi/src/value/create.ts
+++ b/packages/emnapi/src/value/create.ts
@@ -284,15 +284,38 @@ function napi_create_buffer (
 // @ts-expect-error
 ): napi_status {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  let value: number
+  let value: number, pointer: number
 
   $PREAMBLE!(env, (envObject) => {
     $CHECK_ARG!(envObject, result)
-    $from64('result')
-    const arrayBuffer = createArrayBuffer(size, data)
-    const buffer = Buffer.from(arrayBuffer)
+
+    pointer = $makeMalloc('napi_create_buffer', 'size')
+    if (!pointer) throw new Error('Out of memory')
+    $from64('size')
+    for (let i = pointer; i < pointer + size; ++i) {
+      HEAPU8[i] = 0
+    }
+    const pointerInfo: PointerInfo = {
+      address: pointer,
+      ownership: emnapiExternalMemory.registry ? 0 /* emnapi.Ownership.kRuntime */ : 1 /* emnapi.Ownership.kUserland */,
+      runtimeAllocated: 1
+    }
+    const buffer = Buffer.from(HEAPU8.buffer, pointer, size)
+    emnapiExternalMemory.bufferTable.set(buffer, pointerInfo)
+    emnapiExternalMemory.wasmMemoryViewTable.set(buffer, {
+      Ctor: Buffer,
+      ptr: pointer,
+      length: size
+    })
+    emnapiExternalMemory.registry?.register(buffer, pointer)
+
     value = emnapiCtx.addToCurrentScope(buffer).id
+    $from64('result')
     $makeSetValue('result', 0, 'value', '*')
+    if (data) {
+      $from64('data')
+      $makeSetValue('data', 0, 'pointer', '*')
+    }
     return envObject.getReturnStatus()
   })
 }
@@ -410,7 +433,7 @@ emnapiImplement('$createArrayBuffer', undefined, _$createArrayBuffer)
 emnapiImplement('napi_create_array', 'ipp', napi_create_array)
 emnapiImplement('napi_create_array_with_length', 'ippp', napi_create_array_with_length)
 emnapiImplement('napi_create_arraybuffer', 'ipppp', napi_create_arraybuffer, ['$createArrayBuffer'])
-emnapiImplement('napi_create_buffer', 'ippp', napi_create_buffer, ['$createArrayBuffer'])
+emnapiImplement('napi_create_buffer', 'ippp', napi_create_buffer, ['$emnapiExternalMemory'])
 emnapiImplement('napi_create_buffer_copy', 'ippppp', napi_create_buffer_copy, ['$createArrayBuffer'])
 emnapiImplement('napi_create_date', 'ipdp', napi_create_date)
 emnapiImplement('napi_create_external', 'ippppp', napi_create_external)

--- a/packages/emnapi/src/value/create.ts
+++ b/packages/emnapi/src/value/create.ts
@@ -24,8 +24,8 @@ function napi_create_array_with_length (env: napi_env, length: size_t, result: P
   return envObject.clearLastError()
 }
 
-declare const createArrayBuffer: typeof _$createArrayBuffer
-function _$createArrayBuffer (byte_length: size_t, data: void_pp): ArrayBuffer {
+declare const emnapiCreateArrayBuffer: typeof _$emnapiCreateArrayBuffer
+function _$emnapiCreateArrayBuffer (byte_length: size_t, data: void_pp): ArrayBuffer {
   $from64('byte_length')
   byte_length = byte_length >>> 0
   const arrayBuffer = new ArrayBuffer(byte_length)
@@ -48,7 +48,7 @@ function napi_create_arraybuffer (env: napi_env, byte_length: size_t, data: void
   $PREAMBLE!(env, (envObject) => {
     $CHECK_ARG!(envObject, result)
     $from64('result')
-    const arrayBuffer = createArrayBuffer(byte_length, data)
+    const arrayBuffer = emnapiCreateArrayBuffer(byte_length, data)
     value = emnapiCtx.addToCurrentScope(arrayBuffer).id
     $makeSetValue('result', 0, 'value', '*')
     return envObject.getReturnStatus()
@@ -333,12 +333,13 @@ function napi_create_buffer_copy (
 
   $PREAMBLE!(env, (envObject) => {
     $CHECK_ARG!(envObject, result)
-    $from64('result_data')
-    $from64('result')
-    const arrayBuffer = createArrayBuffer(length, result_data)
+    const arrayBuffer = emnapiCreateArrayBuffer(length, result_data)
     const buffer = Buffer.from(arrayBuffer)
+    $from64('data')
+    $from64('length')
     buffer.set(HEAPU8.subarray(data, data + length))
     value = emnapiCtx.addToCurrentScope(buffer).id
+    $from64('result')
     $makeSetValue('result', 0, 'value', '*')
     return envObject.getReturnStatus()
   })
@@ -429,12 +430,12 @@ function node_api_symbol_for (env: napi_env, utf8description: const_char_p, leng
   return envObject.clearLastError()
 }
 
-emnapiImplement('$createArrayBuffer', undefined, _$createArrayBuffer)
+emnapiImplement('$emnapiCreateArrayBuffer', undefined, _$emnapiCreateArrayBuffer, ['$emnapiExternalMemory'])
 emnapiImplement('napi_create_array', 'ipp', napi_create_array)
 emnapiImplement('napi_create_array_with_length', 'ippp', napi_create_array_with_length)
-emnapiImplement('napi_create_arraybuffer', 'ipppp', napi_create_arraybuffer, ['$createArrayBuffer'])
+emnapiImplement('napi_create_arraybuffer', 'ipppp', napi_create_arraybuffer, ['$emnapiCreateArrayBuffer'])
 emnapiImplement('napi_create_buffer', 'ippp', napi_create_buffer, ['$emnapiExternalMemory'])
-emnapiImplement('napi_create_buffer_copy', 'ippppp', napi_create_buffer_copy, ['$createArrayBuffer'])
+emnapiImplement('napi_create_buffer_copy', 'ippppp', napi_create_buffer_copy, ['$emnapiCreateArrayBuffer'])
 emnapiImplement('napi_create_date', 'ipdp', napi_create_date)
 emnapiImplement('napi_create_external', 'ippppp', napi_create_external)
 emnapiImplement('napi_create_external_arraybuffer', 'ipppppp', napi_create_external_arraybuffer, ['$emnapiWrap'])

--- a/packages/emnapi/src/value/create.ts
+++ b/packages/emnapi/src/value/create.ts
@@ -293,6 +293,7 @@ function napi_create_buffer (
 
     let buffer: Uint8Array
     if (!data) {
+      $from64('size')
       buffer = Buffer.alloc(size)
       value = emnapiCtx.addToCurrentScope(buffer).id
       $makeSetValue('result', 0, 'value', '*')

--- a/packages/emnapi/src/value/create.ts
+++ b/packages/emnapi/src/value/create.ts
@@ -229,6 +229,15 @@ function napi_create_typedarray (
         return envObject.setLastError(napi_status.napi_generic_failure)
       }
       const out = new Type(buffer, byte_offset, length)
+      if (buffer === HEAPU8.buffer) {
+        if (!emnapiExternalMemory.wasmMemoryViewTable.has(out)) {
+          emnapiExternalMemory.wasmMemoryViewTable.set(out, {
+            Ctor: Type as any,
+            ptr: byte_offset,
+            length
+          })
+        }
+      }
 
       $from64('result')
 
@@ -377,6 +386,15 @@ function napi_create_dataview (
     }
 
     const dataview = new DataView(buffer, byte_offset, byte_length)
+    if (buffer === HEAPU8.buffer) {
+      if (!emnapiExternalMemory.wasmMemoryViewTable.has(dataview)) {
+        emnapiExternalMemory.wasmMemoryViewTable.set(dataview, {
+          Ctor: DataView,
+          ptr: byte_offset,
+          length: byte_length
+        })
+      }
+    }
     $from64('result')
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -414,6 +432,6 @@ emnapiImplement('napi_create_external_arraybuffer', 'ipppppp', napi_create_exter
 emnapiImplement('napi_create_external_buffer', 'ipppppp', napi_create_external_buffer, ['emnapi_create_memory_view'])
 emnapiImplement('napi_create_object', 'ipp', napi_create_object)
 emnapiImplement('napi_create_symbol', 'ippp', napi_create_symbol)
-emnapiImplement('napi_create_typedarray', 'ipipppp', napi_create_typedarray)
-emnapiImplement('napi_create_dataview', 'ippppp', napi_create_dataview)
+emnapiImplement('napi_create_typedarray', 'ipipppp', napi_create_typedarray, ['$emnapiExternalMemory'])
+emnapiImplement('napi_create_dataview', 'ippppp', napi_create_dataview, ['$emnapiExternalMemory'])
 emnapiImplement('node_api_symbol_for', 'ipppp', node_api_symbol_for, ['$emnapiUtf8ToString'])

--- a/packages/runtime/src/typings/napi.d.ts
+++ b/packages/runtime/src/typings/napi.d.ts
@@ -150,3 +150,19 @@ declare const enum napi_key_conversion {
   napi_key_keep_numbers,
   napi_key_numbers_to_strings
 }
+
+declare const enum emnapi_memory_view_type {
+  emnapi_int8_array,
+  emnapi_uint8_array,
+  emnapi_uint8_clamped_array,
+  emnapi_int16_array,
+  emnapi_uint16_array,
+  emnapi_int32_array,
+  emnapi_uint32_array,
+  emnapi_float32_array,
+  emnapi_float64_array,
+  emnapi_bigint64_array,
+  emnapi_biguint64_array,
+  emnapi_data_view = 16,
+  emnapi_buffer = 17
+}

--- a/packages/runtime/src/typings/napi.d.ts
+++ b/packages/runtime/src/typings/napi.d.ts
@@ -163,6 +163,6 @@ declare const enum emnapi_memory_view_type {
   emnapi_float64_array,
   emnapi_bigint64_array,
   emnapi_biguint64_array,
-  emnapi_data_view = 16,
-  emnapi_buffer = 17
+  emnapi_data_view = -1,
+  emnapi_buffer = -2
 }

--- a/packages/test/buffer/binding.c
+++ b/packages/test/buffer/binding.c
@@ -48,9 +48,9 @@ static napi_value newBuffer(napi_env env, napi_callback_info info) {
           env, theTextSize, (void**)(&theCopy), &theBuffer));
   NAPI_ASSERT(env, theCopy, "Failed to copy static text for newBuffer");
   memcpy(theCopy, theText, theTextSize);
-#ifdef __EMSCRIPTEN__
-  emnapi_sync_memory(env, false, &theBuffer, 0, NAPI_AUTO_LENGTH);
-#endif
+// #ifdef __EMSCRIPTEN__
+//   emnapi_sync_memory(env, false, &theBuffer, 0, NAPI_AUTO_LENGTH);
+// #endif
 
   return theBuffer;
 }

--- a/packages/test/buffer/binding.c
+++ b/packages/test/buffer/binding.c
@@ -49,7 +49,7 @@ static napi_value newBuffer(napi_env env, napi_callback_info info) {
   NAPI_ASSERT(env, theCopy, "Failed to copy static text for newBuffer");
   memcpy(theCopy, theText, theTextSize);
 #ifdef __EMSCRIPTEN__
-  emnapi_sync_memory(env, false, theBuffer, 0, theCopy, NAPI_AUTO_LENGTH, NULL);
+  emnapi_sync_memory(env, false, &theBuffer, 0, NAPI_AUTO_LENGTH);
 #endif
 
   return theBuffer;

--- a/packages/test/buffer/binding.c
+++ b/packages/test/buffer/binding.c
@@ -49,7 +49,7 @@ static napi_value newBuffer(napi_env env, napi_callback_info info) {
   NAPI_ASSERT(env, theCopy, "Failed to copy static text for newBuffer");
   memcpy(theCopy, theText, theTextSize);
 #ifdef __EMSCRIPTEN__
-  emnapi_sync_memory(env, theBuffer, 0, theCopy, NAPI_AUTO_LENGTH, false);
+  emnapi_sync_memory(env, theBuffer, 0, theCopy, NAPI_AUTO_LENGTH, false, NULL);
 #endif
 
   return theBuffer;

--- a/packages/test/buffer/binding.c
+++ b/packages/test/buffer/binding.c
@@ -49,7 +49,7 @@ static napi_value newBuffer(napi_env env, napi_callback_info info) {
   NAPI_ASSERT(env, theCopy, "Failed to copy static text for newBuffer");
   memcpy(theCopy, theText, theTextSize);
 #ifdef __EMSCRIPTEN__
-  emnapi_sync_memory(env, theBuffer, 0, theCopy, NAPI_AUTO_LENGTH, false, NULL);
+  emnapi_sync_memory(env, false, theBuffer, 0, theCopy, NAPI_AUTO_LENGTH, NULL);
 #endif
 
   return theBuffer;

--- a/packages/test/cgen.config.js
+++ b/packages/test/cgen.config.js
@@ -146,7 +146,7 @@ module.exports = function (_options, { isDebug, isEmscripten }) {
       createTarget('symbol', ['./symbol/binding.c'], true),
       createTarget('typedarray', ['./typedarray/binding.c'], true),
       createTarget('buffer', ['./buffer/binding.c'], false),
-      ...(isEmscripten ? [createTarget('emnapitest', ['./emnapitest/binding.c'], true)] : []),
+      ...(isEmscripten ? [createTarget('emnapitest', ['./emnapitest/binding.c'], true, false, ['-sEXPORTED_RUNTIME_METHODS=[\'emnapiSyncMemory\']'])] : []),
       createTarget('version', ['./version/binding.c']),
 
       ...(isEmscripten

--- a/packages/test/emnapitest/binding.c
+++ b/packages/test/emnapitest/binding.c
@@ -60,6 +60,15 @@ static napi_value External(napi_env env, napi_callback_info info) {
   return output_view;
 }
 
+static napi_value GrowMemory(napi_env env, napi_callback_info info) {
+  napi_value result;
+  int64_t adjustedValue;
+
+  NAPI_CALL(env, napi_adjust_external_memory(env, 1, &adjustedValue));
+  NAPI_CALL(env, napi_create_double(env, (double)adjustedValue, &result));
+
+  return result;
+}
 
 static napi_value NullArrayBuffer(napi_env env, napi_callback_info info) {
   static void* data = NULL;
@@ -95,6 +104,7 @@ napi_value Init(napi_env env, napi_value exports) {
     DECLARE_NAPI_PROPERTY("getModuleProperty", getModuleProperty),
     DECLARE_NAPI_PROPERTY("External", External),
     DECLARE_NAPI_PROPERTY("NullArrayBuffer", NullArrayBuffer),
+    DECLARE_NAPI_PROPERTY("GrowMemory", GrowMemory),
     DECLARE_NAPI_PROPERTY("testGetEmscriptenVersion", testGetEmscriptenVersion)
   };
 

--- a/packages/test/emnapitest/binding.c
+++ b/packages/test/emnapitest/binding.c
@@ -50,6 +50,7 @@ static napi_value External(napi_env env, napi_callback_info info) {
   napi_value output_view;
   NAPI_CALL(env, emnapi_create_memory_view(
       env,
+      napi_uint8_array,
       externalData,
       nElem*sizeof(int8_t),
       FinalizeCallback,
@@ -64,7 +65,7 @@ static napi_value NullArrayBuffer(napi_env env, napi_callback_info info) {
   static void* data = NULL;
   napi_value output_view;
   NAPI_CALL(env,
-      emnapi_create_memory_view(env, data, 0, NULL, NULL, &output_view));
+      emnapi_create_memory_view(env, napi_uint8_array, data, 0, NULL, NULL, &output_view));
   return output_view;
 }
 

--- a/packages/test/emnapitest/binding.c
+++ b/packages/test/emnapitest/binding.c
@@ -50,7 +50,7 @@ static napi_value External(napi_env env, napi_callback_info info) {
   napi_value output_view;
   NAPI_CALL(env, emnapi_create_memory_view(
       env,
-      napi_uint8_array,
+      emnapi_uint8_array,
       externalData,
       nElem*sizeof(int8_t),
       FinalizeCallback,
@@ -74,7 +74,7 @@ static napi_value NullArrayBuffer(napi_env env, napi_callback_info info) {
   static void* data = NULL;
   napi_value output_view;
   NAPI_CALL(env,
-      emnapi_create_memory_view(env, napi_uint8_array, data, 0, NULL, NULL, &output_view));
+      emnapi_create_memory_view(env, emnapi_uint8_array, data, 0, NULL, NULL, &output_view));
   return output_view;
 }
 

--- a/packages/test/emnapitest/binding.c
+++ b/packages/test/emnapitest/binding.c
@@ -47,25 +47,25 @@ static napi_value External(napi_env env, napi_callback_info info) {
   externalData[1] = 1;
   externalData[2] = 2;
 
-  napi_value output_array;
-  NAPI_CALL(env, emnapi_create_external_uint8array(
+  napi_value output_view;
+  NAPI_CALL(env, emnapi_create_memory_view(
       env,
       externalData,
       nElem*sizeof(int8_t),
       FinalizeCallback,
       NULL,  // finalize_hint
-      &output_array));
+      &output_view));
 
-  return output_array;
+  return output_view;
 }
 
 
 static napi_value NullArrayBuffer(napi_env env, napi_callback_info info) {
   static void* data = NULL;
-  napi_value output_array;
+  napi_value output_view;
   NAPI_CALL(env,
-      emnapi_create_external_uint8array(env, data, 0, NULL, NULL, &output_array));
-  return output_array;
+      emnapi_create_memory_view(env, data, 0, NULL, NULL, &output_view));
+  return output_view;
 }
 
 static napi_value testGetEmscriptenVersion(napi_env env, napi_callback_info info) {

--- a/packages/test/emnapitest/emnapi.test.js
+++ b/packages/test/emnapitest/emnapi.test.js
@@ -19,7 +19,7 @@ module.exports = promise.then(test_typedarray => {
   assert.ok(externalResult instanceof Uint8Array)
   assert.deepStrictEqual([...externalResult], [0, 1, 2])
   test_typedarray.GrowMemory()
-  externalResult = promise.Module.emnapiSyncMemory(externalResult, 0, 0, -1, false)
+  externalResult = promise.Module.emnapiSyncMemory(false, externalResult)
   assert.deepStrictEqual([...externalResult], [0, 1, 2])
 
   const buffer = test_typedarray.NullArrayBuffer()

--- a/packages/test/emnapitest/emnapi.test.js
+++ b/packages/test/emnapitest/emnapi.test.js
@@ -5,7 +5,9 @@
 const assert = require('assert')
 const { load } = require('../util')
 
-module.exports = load('emnapitest').then(test_typedarray => {
+const promise = load('emnapitest')
+
+module.exports = promise.then(test_typedarray => {
   const mod = test_typedarray.getModuleObject()
 
   const HEAPU8 = test_typedarray.getModuleProperty('HEAPU8')
@@ -13,17 +15,17 @@ module.exports = load('emnapitest').then(test_typedarray => {
   assert.ok(mem instanceof ArrayBuffer || mem instanceof SharedArrayBuffer)
   assert.strictEqual(mod.HEAPU8, HEAPU8)
 
-  const externalResult = test_typedarray.External()
+  let externalResult = test_typedarray.External()
   assert.ok(externalResult instanceof Uint8Array)
-  assert.strictEqual(externalResult.length, 3)
-  assert.strictEqual(externalResult[0], 0)
-  assert.strictEqual(externalResult[1], 1)
-  assert.strictEqual(externalResult[2], 2)
+  assert.deepStrictEqual([...externalResult], [0, 1, 2])
+  test_typedarray.GrowMemory()
+  externalResult = promise.Module.emnapiSyncMemory(externalResult, 0, 0, -1, false)
+  assert.deepStrictEqual([...externalResult], [0, 1, 2])
 
   const buffer = test_typedarray.NullArrayBuffer()
   assert.ok(buffer instanceof Uint8Array)
   assert.strictEqual(buffer.length, 0)
-  assert.strictEqual(buffer.buffer, mem)
+  assert.strictEqual(buffer.buffer, test_typedarray.getModuleProperty('HEAPU8').buffer)
   assert.notStrictEqual(buffer.buffer.byteLength, 0)
 
   const [major, minor, patch] = test_typedarray.testGetEmscriptenVersion()

--- a/packages/test/emnapitest/emnapi.test.js
+++ b/packages/test/emnapitest/emnapi.test.js
@@ -13,14 +13,14 @@ module.exports = load('emnapitest').then(test_typedarray => {
   assert.ok(mem instanceof ArrayBuffer || mem instanceof SharedArrayBuffer)
   assert.strictEqual(mod.HEAPU8, HEAPU8)
 
-  const externalResult = test_typedarray.External().HEAPU8
+  const externalResult = test_typedarray.External()
   assert.ok(externalResult instanceof Uint8Array)
   assert.strictEqual(externalResult.length, 3)
   assert.strictEqual(externalResult[0], 0)
   assert.strictEqual(externalResult[1], 1)
   assert.strictEqual(externalResult[2], 2)
 
-  const buffer = test_typedarray.NullArrayBuffer().HEAPU8
+  const buffer = test_typedarray.NullArrayBuffer()
   assert.ok(buffer instanceof Uint8Array)
   assert.strictEqual(buffer.length, 0)
   assert.strictEqual(buffer.buffer, mem)

--- a/packages/test/emnapitest/emnapi.test.js
+++ b/packages/test/emnapitest/emnapi.test.js
@@ -13,14 +13,14 @@ module.exports = load('emnapitest').then(test_typedarray => {
   assert.ok(mem instanceof ArrayBuffer || mem instanceof SharedArrayBuffer)
   assert.strictEqual(mod.HEAPU8, HEAPU8)
 
-  const externalResult = test_typedarray.External()
+  const externalResult = test_typedarray.External().HEAPU8
   assert.ok(externalResult instanceof Uint8Array)
   assert.strictEqual(externalResult.length, 3)
   assert.strictEqual(externalResult[0], 0)
   assert.strictEqual(externalResult[1], 1)
   assert.strictEqual(externalResult[2], 2)
 
-  const buffer = test_typedarray.NullArrayBuffer()
+  const buffer = test_typedarray.NullArrayBuffer().HEAPU8
   assert.ok(buffer instanceof Uint8Array)
   assert.strictEqual(buffer.length, 0)
   assert.strictEqual(buffer.buffer, mem)

--- a/packages/test/typedarray/binding.c
+++ b/packages/test/typedarray/binding.c
@@ -79,7 +79,7 @@ static napi_value Multiply(napi_env env, napi_callback_info info) {
       output_bytes[i] = (uint8_t)(input_bytes[i] * multiplier);
     }
 #ifdef __EMSCRIPTEN__
-    emnapi_sync_memory(env, output_buffer, 0, output_ptr, NAPI_AUTO_LENGTH, false);
+    emnapi_sync_memory(env, output_buffer, 0, output_ptr, NAPI_AUTO_LENGTH, false, NULL);
 #endif
   } else if (type == napi_float64_array) {
     double* input_doubles = (double*)((uint8_t*)(data) + byte_offset);
@@ -88,7 +88,7 @@ static napi_value Multiply(napi_env env, napi_callback_info info) {
       output_doubles[i] = input_doubles[i] * multiplier;
     }
 #ifdef __EMSCRIPTEN__
-    emnapi_sync_memory(env, output_buffer, 0, output_ptr, NAPI_AUTO_LENGTH, false);
+    emnapi_sync_memory(env, output_buffer, 0, output_ptr, NAPI_AUTO_LENGTH, false, NULL);
 #endif
   } else {
     napi_throw_error(env, NULL,

--- a/packages/test/typedarray/binding.c
+++ b/packages/test/typedarray/binding.c
@@ -79,7 +79,7 @@ static napi_value Multiply(napi_env env, napi_callback_info info) {
       output_bytes[i] = (uint8_t)(input_bytes[i] * multiplier);
     }
 #ifdef __EMSCRIPTEN__
-    emnapi_sync_memory(env, false, output_buffer, 0, output_ptr, NAPI_AUTO_LENGTH, NULL);
+    emnapi_sync_memory(env, false, &output_buffer, 0, NAPI_AUTO_LENGTH);
 #endif
   } else if (type == napi_float64_array) {
     double* input_doubles = (double*)((uint8_t*)(data) + byte_offset);
@@ -88,7 +88,7 @@ static napi_value Multiply(napi_env env, napi_callback_info info) {
       output_doubles[i] = input_doubles[i] * multiplier;
     }
 #ifdef __EMSCRIPTEN__
-    emnapi_sync_memory(env, false, output_buffer, 0, output_ptr, NAPI_AUTO_LENGTH, NULL);
+    emnapi_sync_memory(env, false, &output_buffer, 0, NAPI_AUTO_LENGTH);
 #endif
   } else {
     napi_throw_error(env, NULL,

--- a/packages/test/typedarray/binding.c
+++ b/packages/test/typedarray/binding.c
@@ -79,7 +79,7 @@ static napi_value Multiply(napi_env env, napi_callback_info info) {
       output_bytes[i] = (uint8_t)(input_bytes[i] * multiplier);
     }
 #ifdef __EMSCRIPTEN__
-    emnapi_sync_memory(env, output_buffer, 0, output_ptr, NAPI_AUTO_LENGTH, false, NULL);
+    emnapi_sync_memory(env, false, output_buffer, 0, output_ptr, NAPI_AUTO_LENGTH, NULL);
 #endif
   } else if (type == napi_float64_array) {
     double* input_doubles = (double*)((uint8_t*)(data) + byte_offset);
@@ -88,7 +88,7 @@ static napi_value Multiply(napi_env env, napi_callback_info info) {
       output_doubles[i] = input_doubles[i] * multiplier;
     }
 #ifdef __EMSCRIPTEN__
-    emnapi_sync_memory(env, output_buffer, 0, output_ptr, NAPI_AUTO_LENGTH, false, NULL);
+    emnapi_sync_memory(env, false, output_buffer, 0, output_ptr, NAPI_AUTO_LENGTH, NULL);
 #endif
   } else {
     napi_throw_error(env, NULL,


### PR DESCRIPTION
#16 

There is no way to reset detached `TypedArray.prototype.buffer` to newly growed wasm memory ArrayBuffer.