### PR TITLE
Support `async_hooks` on Node.js

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,7 @@ jobs:
       if: ${{ matrix.os == 'ubuntu-latest' }}
       shell: bash
       run: |
+        npm install -g node-gyp
         npm install --legacy-peer-deps
         npm run build --workspaces --if-present
     
@@ -69,7 +70,7 @@ jobs:
       if: ${{ startsWith(github.event.ref, 'refs/tags') && matrix.os == 'ubuntu-latest' }}
       run: |
         node ./script/release.js
-        npm publish --ignore-scripts -w packages/runtime -w packages/emnapi
+        npm publish --ignore-scripts -w packages/runtime -w packages/node -w packages/emnapi
 
     - name: Create release
       if: ${{ startsWith(github.event.ref, 'refs/tags') }}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
       "request": "launch",
       "name": "Launch Program",
       "runtimeArgs": ["--expose-gc"],
-      "program": "${workspaceFolder}/packages/test/async/async_hooks.test.js",
+      "program": "${workspaceFolder}/packages/test/make_callback/make_callback.test.js",
       "args": []
     },
     {

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,8 +6,13 @@
       "request": "launch",
       "name": "Launch Program",
       "runtimeArgs": ["--expose-gc"],
-      "program": "${workspaceFolder}/packages/test/tsfn/tsfn.test.js",
+      "program": "${workspaceFolder}/packages/test/async/async_hooks.test.js",
       "args": []
+    },
+    {
+      "name": "Windows Attach",
+      "type": "cppvsdbg",
+      "request": "attach",
     },
     {
       "name": "Windows",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "workspaces": [
     "packages/runtime",
+    "packages/node",
     "packages/emnapi",
     "packages/test",
     "packages/bench"

--- a/packages/emnapi/README.md
+++ b/packages/emnapi/README.md
@@ -60,6 +60,7 @@ nmake /?
 ```bash
 git clone https://github.com/toyobayashi/emnapi.git
 cd ./emnapi
+npm install -g node-gyp
 npm install
 npm run build             # output ./packages/*/dist
 node ./script/release.js  # output ./out
@@ -162,7 +163,21 @@ declare namespace emnapi {
 declare namespace Module {
   interface EmnapiInitOptions {
     context: emnapi.Context
+
+    /** node_api_get_module_file_name */
     filename?: string
+
+    /**
+     * Support following async_hooks related things
+     * on Node.js runtime only
+     * 
+     * napi_async_init,
+     * napi_async_destroy,
+     * napi_make_callback,
+     * async resource parameter of
+     * napi_create_async_work and napi_create_threadsafe_function
+     */
+    nodeBinding?: typeof import('@tybys/emnapi-node-binding')
   }
   export function emnapiInit (options: EmnapiInitOptions): any
 }
@@ -224,7 +239,7 @@ Module({ /* Emscripten module init options */ }).then((Module) => {
 
 ### Using C++
 
-Alternatively, you can also use [`node-addon-api`](https://github.com/nodejs/node-addon-api) which is official Node-API C++ wrapper, already shipped ([v5.1.0](https://github.com/nodejs/node-addon-api/releases/tag/v5.1.0)) in this package but without Node.js specific API such as `AsyncContext`, `Function::MakeCallback`, etc.
+Alternatively, you can also use [`node-addon-api`](https://github.com/nodejs/node-addon-api) which is official Node-API C++ wrapper, already shipped ([v5.1.0](https://github.com/nodejs/node-addon-api/releases/tag/v5.1.0)) in this package but without Node.js specific API such as `CallbackScope`.
 
 **Note: C++ wrapper can only be used to target Node.js v14.6.0+ and modern browsers those support `FinalizationRegistry` and `WeakRef` ([v8 engine v8.4+](https://v8.dev/blog/v8-release-84))!**
 

--- a/packages/emnapi/include/emnapi.h
+++ b/packages/emnapi/include/emnapi.h
@@ -35,6 +35,7 @@ EXTERN_C_START
 
 NAPI_EXTERN int emnapi_is_support_weakref();
 NAPI_EXTERN int emnapi_is_support_bigint();
+NAPI_EXTERN int emnapi_is_node_binding_available();
 
 NAPI_EXTERN
 napi_status emnapi_get_module_object(napi_env env,

--- a/packages/emnapi/include/napi-inl.h
+++ b/packages/emnapi/include/napi-inl.h
@@ -2332,31 +2332,31 @@ inline MaybeOrValue<Value> Function::Call(napi_value recv,
       _env, status, Napi::Value(_env, result), Napi::Value);
 }
 
-// inline MaybeOrValue<Value> Function::MakeCallback(
-//     napi_value recv,
-//     const std::initializer_list<napi_value>& args,
-//     napi_async_context context) const {
-//   return MakeCallback(recv, args.size(), args.begin(), context);
-// }
+inline MaybeOrValue<Value> Function::MakeCallback(
+    napi_value recv,
+    const std::initializer_list<napi_value>& args,
+    napi_async_context context) const {
+  return MakeCallback(recv, args.size(), args.begin(), context);
+}
 
-// inline MaybeOrValue<Value> Function::MakeCallback(
-//     napi_value recv,
-//     const std::vector<napi_value>& args,
-//     napi_async_context context) const {
-//   return MakeCallback(recv, args.size(), args.data(), context);
-// }
+inline MaybeOrValue<Value> Function::MakeCallback(
+    napi_value recv,
+    const std::vector<napi_value>& args,
+    napi_async_context context) const {
+  return MakeCallback(recv, args.size(), args.data(), context);
+}
 
-// inline MaybeOrValue<Value> Function::MakeCallback(
-//     napi_value recv,
-//     size_t argc,
-//     const napi_value* args,
-//     napi_async_context context) const {
-//   napi_value result;
-//   napi_status status =
-//       napi_make_callback(_env, context, recv, _value, argc, args, &result);
-//   NAPI_RETURN_OR_THROW_IF_FAILED(
-//       _env, status, Napi::Value(_env, result), Napi::Value);
-// }
+inline MaybeOrValue<Value> Function::MakeCallback(
+    napi_value recv,
+    size_t argc,
+    const napi_value* args,
+    napi_async_context context) const {
+  napi_value result;
+  napi_status status =
+      napi_make_callback(_env, context, recv, _value, argc, args, &result);
+  NAPI_RETURN_OR_THROW_IF_FAILED(
+      _env, status, Napi::Value(_env, result), Napi::Value);
+}
 
 inline MaybeOrValue<Object> Function::New(
     const std::initializer_list<napi_value>& args) const {
@@ -3326,65 +3326,65 @@ inline MaybeOrValue<Napi::Value> FunctionReference::Call(
 #endif
 }
 
-// inline MaybeOrValue<Napi::Value> FunctionReference::MakeCallback(
-//     napi_value recv,
-//     const std::initializer_list<napi_value>& args,
-//     napi_async_context context) const {
-//   EscapableHandleScope scope(_env);
-//   MaybeOrValue<Napi::Value> result = Value().MakeCallback(recv, args, context);
-// #ifdef NODE_ADDON_API_ENABLE_MAYBE
-//   if (result.IsJust()) {
-//     return Just(scope.Escape(result.Unwrap()));
-//   }
+inline MaybeOrValue<Napi::Value> FunctionReference::MakeCallback(
+    napi_value recv,
+    const std::initializer_list<napi_value>& args,
+    napi_async_context context) const {
+  EscapableHandleScope scope(_env);
+  MaybeOrValue<Napi::Value> result = Value().MakeCallback(recv, args, context);
+#ifdef NODE_ADDON_API_ENABLE_MAYBE
+  if (result.IsJust()) {
+    return Just(scope.Escape(result.Unwrap()));
+  }
 
-//   return result;
-// #else
-//   if (scope.Env().IsExceptionPending()) {
-//     return Value();
-//   }
-//   return scope.Escape(result);
-// #endif
-// }
+  return result;
+#else
+  if (scope.Env().IsExceptionPending()) {
+    return Value();
+  }
+  return scope.Escape(result);
+#endif
+}
 
-// inline MaybeOrValue<Napi::Value> FunctionReference::MakeCallback(
-//     napi_value recv,
-//     const std::vector<napi_value>& args,
-//     napi_async_context context) const {
-//   EscapableHandleScope scope(_env);
-//   MaybeOrValue<Napi::Value> result = Value().MakeCallback(recv, args, context);
-// #ifdef NODE_ADDON_API_ENABLE_MAYBE
-//   if (result.IsJust()) {
-//     return Just(scope.Escape(result.Unwrap()));
-//   }
-//   return result;
-// #else
-//   if (scope.Env().IsExceptionPending()) {
-//     return Value();
-//   }
-//   return scope.Escape(result);
-// #endif
-// }
+inline MaybeOrValue<Napi::Value> FunctionReference::MakeCallback(
+    napi_value recv,
+    const std::vector<napi_value>& args,
+    napi_async_context context) const {
+  EscapableHandleScope scope(_env);
+  MaybeOrValue<Napi::Value> result = Value().MakeCallback(recv, args, context);
+#ifdef NODE_ADDON_API_ENABLE_MAYBE
+  if (result.IsJust()) {
+    return Just(scope.Escape(result.Unwrap()));
+  }
+  return result;
+#else
+  if (scope.Env().IsExceptionPending()) {
+    return Value();
+  }
+  return scope.Escape(result);
+#endif
+}
 
-// inline MaybeOrValue<Napi::Value> FunctionReference::MakeCallback(
-//     napi_value recv,
-//     size_t argc,
-//     const napi_value* args,
-//     napi_async_context context) const {
-//   EscapableHandleScope scope(_env);
-//   MaybeOrValue<Napi::Value> result =
-//       Value().MakeCallback(recv, argc, args, context);
-// #ifdef NODE_ADDON_API_ENABLE_MAYBE
-//   if (result.IsJust()) {
-//     return Just(scope.Escape(result.Unwrap()));
-//   }
-//   return result;
-// #else
-//   if (scope.Env().IsExceptionPending()) {
-//     return Value();
-//   }
-//   return scope.Escape(result);
-// #endif
-// }
+inline MaybeOrValue<Napi::Value> FunctionReference::MakeCallback(
+    napi_value recv,
+    size_t argc,
+    const napi_value* args,
+    napi_async_context context) const {
+  EscapableHandleScope scope(_env);
+  MaybeOrValue<Napi::Value> result =
+      Value().MakeCallback(recv, argc, args, context);
+#ifdef NODE_ADDON_API_ENABLE_MAYBE
+  if (result.IsJust()) {
+    return Just(scope.Escape(result.Unwrap()));
+  }
+  return result;
+#else
+  if (scope.Env().IsExceptionPending()) {
+    return Value();
+  }
+  return scope.Escape(result);
+#endif
+}
 
 inline MaybeOrValue<Object> FunctionReference::New(
     const std::initializer_list<napi_value>& args) const {
@@ -4672,51 +4672,51 @@ inline Value EscapableHandleScope::Escape(napi_value escapee) {
 // AsyncContext class
 ////////////////////////////////////////////////////////////////////////////////
 
-// inline AsyncContext::AsyncContext(napi_env env, const char* resource_name)
-//     : AsyncContext(env, resource_name, Object::New(env)) {}
+inline AsyncContext::AsyncContext(napi_env env, const char* resource_name)
+    : AsyncContext(env, resource_name, Object::New(env)) {}
 
-// inline AsyncContext::AsyncContext(napi_env env,
-//                                   const char* resource_name,
-//                                   const Object& resource)
-//     : _env(env), _context(nullptr) {
-//   napi_value resource_id;
-//   napi_status status = napi_create_string_utf8(
-//       _env, resource_name, NAPI_AUTO_LENGTH, &resource_id);
-//   NAPI_THROW_IF_FAILED_VOID(_env, status);
+inline AsyncContext::AsyncContext(napi_env env,
+                                  const char* resource_name,
+                                  const Object& resource)
+    : _env(env), _context(nullptr) {
+  napi_value resource_id;
+  napi_status status = napi_create_string_utf8(
+      _env, resource_name, NAPI_AUTO_LENGTH, &resource_id);
+  NAPI_THROW_IF_FAILED_VOID(_env, status);
 
-//   status = napi_async_init(_env, resource, resource_id, &_context);
-//   NAPI_THROW_IF_FAILED_VOID(_env, status);
-// }
+  status = napi_async_init(_env, resource, resource_id, &_context);
+  NAPI_THROW_IF_FAILED_VOID(_env, status);
+}
 
-// inline AsyncContext::~AsyncContext() {
-//   if (_context != nullptr) {
-//     napi_async_destroy(_env, _context);
-//     _context = nullptr;
-//   }
-// }
+inline AsyncContext::~AsyncContext() {
+  if (_context != nullptr) {
+    napi_async_destroy(_env, _context);
+    _context = nullptr;
+  }
+}
 
-// inline AsyncContext::AsyncContext(AsyncContext&& other) {
-//   _env = other._env;
-//   other._env = nullptr;
-//   _context = other._context;
-//   other._context = nullptr;
-// }
+inline AsyncContext::AsyncContext(AsyncContext&& other) {
+  _env = other._env;
+  other._env = nullptr;
+  _context = other._context;
+  other._context = nullptr;
+}
 
-// inline AsyncContext& AsyncContext::operator=(AsyncContext&& other) {
-//   _env = other._env;
-//   other._env = nullptr;
-//   _context = other._context;
-//   other._context = nullptr;
-//   return *this;
-// }
+inline AsyncContext& AsyncContext::operator=(AsyncContext&& other) {
+  _env = other._env;
+  other._env = nullptr;
+  _context = other._context;
+  other._context = nullptr;
+  return *this;
+}
 
-// inline AsyncContext::operator napi_async_context() const {
-//   return _context;
-// }
+inline AsyncContext::operator napi_async_context() const {
+  return _context;
+}
 
-// inline Napi::Env AsyncContext::Env() const {
-//   return Napi::Env(_env);
-// }
+inline Napi::Env AsyncContext::Env() const {
+  return Napi::Env(_env);
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // AsyncWorker class

--- a/packages/emnapi/include/napi.h
+++ b/packages/emnapi/include/napi.h
@@ -1389,17 +1389,17 @@ class Function : public Object {
                            size_t argc,
                            const napi_value* args) const;
 
-  // MaybeOrValue<Value> MakeCallback(
-  //     napi_value recv,
-  //     const std::initializer_list<napi_value>& args,
-  //     napi_async_context context = nullptr) const;
-  // MaybeOrValue<Value> MakeCallback(napi_value recv,
-  //                                  const std::vector<napi_value>& args,
-  //                                  napi_async_context context = nullptr) const;
-  // MaybeOrValue<Value> MakeCallback(napi_value recv,
-  //                                  size_t argc,
-  //                                  const napi_value* args,
-  //                                  napi_async_context context = nullptr) const;
+  MaybeOrValue<Value> MakeCallback(
+      napi_value recv,
+      const std::initializer_list<napi_value>& args,
+      napi_async_context context = nullptr) const;
+  MaybeOrValue<Value> MakeCallback(napi_value recv,
+                                   const std::vector<napi_value>& args,
+                                   napi_async_context context = nullptr) const;
+  MaybeOrValue<Value> MakeCallback(napi_value recv,
+                                   size_t argc,
+                                   const napi_value* args,
+                                   napi_async_context context = nullptr) const;
 
   MaybeOrValue<Object> New(const std::initializer_list<napi_value>& args) const;
   MaybeOrValue<Object> New(const std::vector<napi_value>& args) const;
@@ -1583,19 +1583,19 @@ class FunctionReference : public Reference<Function> {
                                  size_t argc,
                                  const napi_value* args) const;
 
-  // MaybeOrValue<Napi::Value> MakeCallback(
-  //     napi_value recv,
-  //     const std::initializer_list<napi_value>& args,
-  //     napi_async_context context = nullptr) const;
-  // MaybeOrValue<Napi::Value> MakeCallback(
-  //     napi_value recv,
-  //     const std::vector<napi_value>& args,
-  //     napi_async_context context = nullptr) const;
-  // MaybeOrValue<Napi::Value> MakeCallback(
-  //     napi_value recv,
-  //     size_t argc,
-  //     const napi_value* args,
-  //     napi_async_context context = nullptr) const;
+  MaybeOrValue<Napi::Value> MakeCallback(
+      napi_value recv,
+      const std::initializer_list<napi_value>& args,
+      napi_async_context context = nullptr) const;
+  MaybeOrValue<Napi::Value> MakeCallback(
+      napi_value recv,
+      const std::vector<napi_value>& args,
+      napi_async_context context = nullptr) const;
+  MaybeOrValue<Napi::Value> MakeCallback(
+      napi_value recv,
+      size_t argc,
+      const napi_value* args,
+      napi_async_context context = nullptr) const;
 
   MaybeOrValue<Object> New(const std::initializer_list<napi_value>& args) const;
   MaybeOrValue<Object> New(const std::vector<napi_value>& args) const;
@@ -2414,26 +2414,26 @@ class EscapableHandleScope {
 // };
 // #endif
 
-// class AsyncContext {
-//  public:
-//   explicit AsyncContext(napi_env env, const char* resource_name);
-//   explicit AsyncContext(napi_env env,
-//                         const char* resource_name,
-//                         const Object& resource);
-//   virtual ~AsyncContext();
+class AsyncContext {
+ public:
+  explicit AsyncContext(napi_env env, const char* resource_name);
+  explicit AsyncContext(napi_env env,
+                        const char* resource_name,
+                        const Object& resource);
+  virtual ~AsyncContext();
 
-//   AsyncContext(AsyncContext&& other);
-//   AsyncContext& operator=(AsyncContext&& other);
-//   NAPI_DISALLOW_ASSIGN_COPY(AsyncContext)
+  AsyncContext(AsyncContext&& other);
+  AsyncContext& operator=(AsyncContext&& other);
+  NAPI_DISALLOW_ASSIGN_COPY(AsyncContext)
 
-//   operator napi_async_context() const;
+  operator napi_async_context() const;
 
-//   Napi::Env Env() const;
+  Napi::Env Env() const;
 
-//  private:
-//   napi_env _env;
-//   napi_async_context _context;
-// };
+ private:
+  napi_env _env;
+  napi_async_context _context;
+};
 
 class AsyncWorker {
  public:

--- a/packages/emnapi/include/node_api.h
+++ b/packages/emnapi/include/node_api.h
@@ -67,6 +67,25 @@ NAPI_EXTERN NAPI_NO_RETURN void napi_fatal_error(const char* location,
                                                  const char* message,
                                                  size_t message_len);
 
+// Methods for custom handling of async operations
+NAPI_EXTERN napi_status
+napi_async_init(napi_env env,
+                napi_value async_resource,
+                napi_value async_resource_name,
+                napi_async_context* result);
+
+NAPI_EXTERN napi_status
+napi_async_destroy(napi_env env, napi_async_context async_context);
+
+NAPI_EXTERN napi_status
+napi_make_callback(napi_env env,
+                   napi_async_context async_context,
+                   napi_value recv,
+                   napi_value func,
+                   size_t argc,
+                   const napi_value* argv,
+                   napi_value* result);
+
 // Methods to provide node::Buffer functionality with napi types
 NAPI_EXTERN napi_status
 napi_create_buffer(napi_env env,

--- a/packages/emnapi/include/node_api_types.h
+++ b/packages/emnapi/include/node_api_types.h
@@ -3,6 +3,7 @@
 
 #include "js_native_api_types.h"
 
+typedef struct napi_async_context__* napi_async_context;
 typedef struct napi_async_work__* napi_async_work;
 
 #if NAPI_VERSION >= 3

--- a/packages/emnapi/src/emnapi.c
+++ b/packages/emnapi/src/emnapi.c
@@ -242,8 +242,6 @@ extern void _emnapi_env_unref(napi_env env);
 extern void _emnapi_ctx_increase_waiting_request_counter();
 extern void _emnapi_ctx_decrease_waiting_request_counter();
 
-extern int _emnapi_node_binding_available();
-
 struct napi_async_context__ {
   int32_t low;
   int32_t high;
@@ -261,10 +259,6 @@ napi_async_init(napi_env env,
                 napi_value async_resource,
                 napi_value async_resource_name,
                 napi_async_context* result) {
-  if (!_emnapi_node_binding_available()) {
-    return napi_set_last_error(env, napi_generic_failure, 0, NULL);
-  }
-
   CHECK_ENV(env);
   CHECK_ARG(env, async_resource_name);
   CHECK_ARG(env, result);
@@ -439,7 +433,7 @@ static void async_work_after_thread_pool_work(napi_async_work work, int status) 
   assert(wrap != NULL);
   wrap->status = status;
   wrap->work = work;
-  if (_emnapi_node_binding_available()) {
+  if (emnapi_is_node_binding_available()) {
     assert(napi_ok == napi_create_function(env, NULL, 0, async_work_after_cb, wrap, &cb));
     assert(napi_ok == _emnapi_node_make_callback(env,
                                                  resource,
@@ -784,7 +778,7 @@ static void _emnapi_tsfn_finalize(napi_threadsafe_function func) {
   napi_handle_scope scope;
   napi_open_handle_scope(func->env, &scope);
   if (func->finalize_cb) {
-    if (_emnapi_node_binding_available()) {
+    if (emnapi_is_node_binding_available()) {
       napi_value resource, cb;
       assert(napi_ok == napi_get_reference_value(func->env, func->resource_, &resource));
       assert(napi_ok == napi_create_function(func->env, NULL, 0, _emnapi_tsfn_finalize_in_callback_scope, func, &cb));
@@ -905,7 +899,7 @@ static bool _emnapi_tsfn_dispatch_one(napi_threadsafe_function func) {
       jscb_data[1] = (void*)js_callback;
     }
 
-    if (_emnapi_node_binding_available()) {
+    if (emnapi_is_node_binding_available()) {
       napi_value resource, cb;
       assert(napi_ok == napi_get_reference_value(func->env, func->resource_, &resource));
       assert(napi_ok == napi_create_function(func->env, NULL, 0, _emnapi_tsfn_call_js_cb_in_callback_scope, jscb_data, &cb));

--- a/packages/emnapi/src/emnapi.c
+++ b/packages/emnapi/src/emnapi.c
@@ -242,6 +242,59 @@ extern void _emnapi_env_unref(napi_env env);
 extern void _emnapi_ctx_increase_waiting_request_counter();
 extern void _emnapi_ctx_decrease_waiting_request_counter();
 
+extern int _emnapi_node_binding_available();
+
+struct napi_async_context__ {
+  int32_t low;
+  int32_t high;
+};
+
+extern napi_status
+_emnapi_async_init_js(napi_value async_resource,
+                      napi_value async_resource_name,
+                      napi_async_context result);
+extern napi_status
+_emnapi_async_destroy_js(napi_async_context async_context);
+
+napi_status
+napi_async_init(napi_env env,
+                napi_value async_resource,
+                napi_value async_resource_name,
+                napi_async_context* result) {
+  if (!_emnapi_node_binding_available()) {
+    return napi_set_last_error(env, napi_generic_failure, 0, NULL);
+  }
+
+  CHECK_ENV(env);
+  CHECK_ARG(env, async_resource_name);
+  CHECK_ARG(env, result);
+
+  napi_async_context ret = (napi_async_context) malloc(sizeof(struct napi_async_context__));
+
+  napi_status status = _emnapi_async_init_js(async_resource, async_resource_name, ret);
+  if (status != napi_ok) {
+    free(ret);
+    return napi_set_last_error(env, status, 0, NULL);
+  }
+
+  *result = ret;
+  return napi_clear_last_error(env);
+}
+
+napi_status napi_async_destroy(napi_env env,
+                               napi_async_context async_context) {
+  CHECK_ENV(env);
+  CHECK_ARG(env, async_context);
+
+  napi_status status = _emnapi_async_destroy_js(async_context);
+  if (status != napi_ok) {
+    return napi_set_last_error(env, status, 0, NULL);
+  }
+  free(async_context);
+
+  return napi_clear_last_error(env);
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // Async work implementation
 ////////////////////////////////////////////////////////////////////////////////
@@ -259,8 +312,6 @@ typedef struct async_context {
   async_id async_id;
   async_id trigger_async_id;
 } async_context;
-
-extern int _emnapi_node_binding_available();
 
 // call node::EmitAsyncInit
 extern void _emnapi_node_emit_async_init(napi_value async_resource,

--- a/packages/emnapi/src/emnapi.ts
+++ b/packages/emnapi/src/emnapi.ts
@@ -142,6 +142,10 @@ function emnapi_is_support_bigint (): int {
   return emnapiCtx.feature.supportBigInt ? 1 : 0
 }
 
+function emnapi_is_node_binding_available (): int {
+  return emnapiNodeBinding ? 1 : 0
+}
+
 declare function emnapiSyncMemory<T extends ArrayBuffer | ArrayBufferView> (
   js_to_wasm: boolean,
   arrayBufferOrView: T,
@@ -291,6 +295,7 @@ function emnapi_get_memory_address (env: napi_env, arraybuffer_or_view: napi_val
 
 emnapiImplement('emnapi_is_support_weakref', 'i', emnapi_is_support_weakref)
 emnapiImplement('emnapi_is_support_bigint', 'i', emnapi_is_support_bigint)
+emnapiImplement('emnapi_is_node_binding_available', 'i', emnapi_is_node_binding_available)
 emnapiImplement('emnapi_get_module_object', 'ipp', emnapi_get_module_object)
 emnapiImplement('emnapi_get_module_property', 'ippp', emnapi_get_module_property)
 emnapiImplement('emnapi_create_memory_view', 'ipippppp', emnapi_create_memory_view, ['napi_add_finalizer', '$emnapiExternalMemory'])

--- a/packages/emnapi/src/init.ts
+++ b/packages/emnapi/src/init.ts
@@ -8,6 +8,8 @@
 // declare const __webpack_public_path__: any
 
 declare let emnapiCtx: Context
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+declare let emnapiNodeBinding: NodeBinding
 
 declare function _napi_register_wasm_v1 (env: Ptr, exports: Ptr): napi_value
 
@@ -21,17 +23,19 @@ declare const emnapiModule: {
 declare interface InitOptions {
   context: Context
   filename?: string
+  nodeBinding?: NodeBinding
 }
 
 mergeInto(LibraryManager.library, {
   $emnapiCtx: undefined,
+  $emnapiNodeBinding: undefined,
   $emnapiModule: {
     exports: {},
     loaded: false,
     filename: ''
   },
 
-  $emnapiInit__deps: ['$emnapiModule', '$emnapiCtx', 'napi_register_wasm_v1'],
+  $emnapiInit__deps: ['$emnapiModule', '$emnapiCtx', '$emnapiNodeBinding', 'napi_register_wasm_v1'],
   $emnapiInit: function (options: InitOptions) {
     if (emnapiModule.loaded) return emnapiModule.exports
 
@@ -40,7 +44,6 @@ mergeInto(LibraryManager.library, {
     }
 
     const context = options.context
-
     if (typeof context !== 'object' || context === null) {
       throw new TypeError("Invalid `options.context`. You can create a context by `import { createContext } from '@tybys/emnapi-runtime`'")
     }
@@ -49,6 +52,14 @@ mergeInto(LibraryManager.library, {
 
     if (typeof options.filename === 'string') {
       emnapiModule.filename = options.filename
+    }
+
+    if ('nodeBinding' in options) {
+      const nodeBinding = options.nodeBinding
+      if (typeof nodeBinding !== 'object' || nodeBinding === null) {
+        throw new TypeError('Invalid `options.nodeBinding`. Use @tybys/emnapi-node-binding package')
+      }
+      emnapiNodeBinding = nodeBinding
     }
 
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing

--- a/packages/emnapi/src/node.ts
+++ b/packages/emnapi/src/node.ts
@@ -85,9 +85,105 @@ function _emnapi_node_make_callback (env: napi_env, async_resource: napi_value, 
   })
 }
 
+function _emnapi_async_init_js (async_resource: napi_value, async_resource_name: napi_value, result: Pointer<int64_t>): napi_status {
+  let resource: object | undefined
+
+  if (async_resource) {
+    resource = Object(emnapiCtx.handleStore.get(async_resource)!.value)
+  }
+
+  const name = emnapiCtx.handleStore.get(async_resource_name)!.value
+  const ret = emnapiNodeBinding.napi.asyncInit(resource, name)
+  if (ret.status !== 0) return ret.status
+
+  let numberValue = ret.value
+  if (!((numberValue >= (BigInt(-1) * (BigInt(1) << BigInt(63)))) && (numberValue < (BigInt(1) << BigInt(63))))) {
+    numberValue = numberValue & ((BigInt(1) << BigInt(64)) - BigInt(1))
+    if (numberValue >= (BigInt(1) << BigInt(63))) {
+      numberValue = numberValue - (BigInt(1) << BigInt(64))
+    }
+  }
+  const low = Number(numberValue & BigInt(0xffffffff))
+  const high = Number(numberValue >> BigInt(32))
+  $from64('result')
+  HEAP32[result >> 2] = low
+  HEAP32[result + 4 >> 2] = high
+
+  return napi_status.napi_ok
+}
+
+function _emnapi_async_destroy_js (async_context: Pointer<int64_t>): napi_status {
+  $from64('async_context')
+  const low = $makeGetValue('async_context', 0, 'i32')
+  const high = $makeGetValue('async_context', 4, 'i32')
+
+  const pointer = BigInt((low as number) >>> 0) | (BigInt(high) << BigInt(32))
+
+  const ret = emnapiNodeBinding.napi.asyncDestroy(pointer)
+  if (ret.status !== 0) return ret.status
+
+  return napi_status.napi_ok
+}
+
+// @ts-expect-error
+function napi_make_callback (env: napi_env, async_context: Pointer<int64_t>, recv: napi_value, func: napi_value, argc: size_t, argv: Pointer<napi_value>, result: Pointer<napi_value>): napi_status {
+  let i = 0
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  let v: number
+
+  $PREAMBLE!(env, (envObject) => {
+    if (!emnapiNodeBinding) {
+      return envObject.setLastError(napi_status.napi_generic_failure)
+    }
+    $CHECK_ARG!(envObject, recv)
+    if (argc > 0) {
+      $CHECK_ARG!(envObject, argv)
+    }
+
+    const v8recv = Object(emnapiCtx.handleStore.get(recv)!.value)
+    const v8func = emnapiCtx.handleStore.get(func)!.value
+    if (typeof v8func !== 'function') {
+      return envObject.setLastError(napi_status.napi_invalid_arg)
+    }
+
+    $from64('async_context')
+    const low = $makeGetValue('async_context', 0, 'i32')
+    const high = $makeGetValue('async_context', 4, 'i32')
+    const ctx = BigInt((low as number) >>> 0) | (BigInt(high) << BigInt(32))
+
+    $from64('argv')
+    $from64('argc')
+    argc = argc >>> 0
+    const arr = Array(argc)
+    for (; i < argc; i++) {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/restrict-plus-operands
+      const argVal = $makeGetValue('argv', 'i * ' + POINTER_SIZE, '*')
+      arr[i] = emnapiCtx.handleStore.get(argVal)!.value
+    }
+    const ret = emnapiNodeBinding.napi.makeCallback(ctx, v8recv, v8func, arr)
+    if (ret.error) {
+      throw ret.error
+    }
+
+    if (ret.status !== napi_status.napi_ok) return envObject.setLastError(ret.status)
+
+    if (result) {
+      $from64('result')
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      v = envObject.ensureHandleId(ret.value)
+      $makeSetValue('result', 0, 'v', '*')
+    }
+    return envObject.clearLastError()
+  })
+}
+
 emnapiImplement('_emnapi_node_binding_available', 'i', _emnapi_node_binding_available)
 emnapiImplement('_emnapi_node_emit_async_init', 'vppdp', _emnapi_node_emit_async_init)
 emnapiImplement('_emnapi_node_emit_async_destroy', 'vdd', _emnapi_node_emit_async_destroy)
 // emnapiImplement('_emnapi_node_open_callback_scope', 'vpddp', _emnapi_node_open_callback_scope)
 // emnapiImplement('_emnapi_node_close_callback_scope', 'vp', _emnapi_node_close_callback_scope)
 emnapiImplement('_emnapi_node_make_callback', 'ipppppddp', _emnapi_node_make_callback)
+
+emnapiImplement('_emnapi_async_init_js', 'ippp', _emnapi_async_init_js)
+emnapiImplement('_emnapi_async_destroy_js', 'ip', _emnapi_async_destroy_js)
+emnapiImplement('napi_make_callback', 'ippppppp', napi_make_callback)

--- a/packages/emnapi/src/node.ts
+++ b/packages/emnapi/src/node.ts
@@ -12,7 +12,7 @@ function _emnapi_node_emit_async_init (
   const resource = emnapiCtx.handleStore.get(async_resource)!.value
   const resource_name = emnapiCtx.handleStore.get(async_resource_name)!.value
 
-  const asyncContext = emnapiNodeBinding.emitAsyncInit(resource, resource_name, trigger_async_id)
+  const asyncContext = emnapiNodeBinding.node.emitAsyncInit(resource, resource_name, trigger_async_id)
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const asyncId = asyncContext.asyncId; const triggerAsyncId = asyncContext.triggerAsyncId
   if (result) {
@@ -24,7 +24,7 @@ function _emnapi_node_emit_async_init (
 
 function _emnapi_node_emit_async_destroy (async_id: double, trigger_async_id: double): void {
   if (!emnapiNodeBinding) return
-  emnapiNodeBinding.emitAsyncDestroy({
+  emnapiNodeBinding.node.emitAsyncDestroy({
     asyncId: async_id,
     triggerAsyncId: trigger_async_id
   })
@@ -34,7 +34,7 @@ function _emnapi_node_emit_async_destroy (async_id: double, trigger_async_id: do
   if (!emnapiNodeBinding || !result) return
   const resource = emnapiCtx.handleStore.get(async_resource)!.value
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const nativeCallbackScopePointer = emnapiNodeBinding.openCallbackScope(resource, {
+  const nativeCallbackScopePointer = emnapiNodeBinding.node.openCallbackScope(resource, {
     asyncId: async_id,
     triggerAsyncId: trigger_async_id
   })
@@ -47,7 +47,7 @@ function _emnapi_node_close_callback_scope (scope: Pointer<int64_t>): void {
   if (!emnapiNodeBinding || !scope) return
   $from64('scope')
   const nativeCallbackScopePointer = $makeGetValue('scope', 0, 'i64')
-  emnapiNodeBinding.closeCallbackScope(BigInt(nativeCallbackScopePointer))
+  emnapiNodeBinding.node.closeCallbackScope(BigInt(nativeCallbackScopePointer))
 } */
 
 // @ts-expect-error
@@ -71,7 +71,7 @@ function _emnapi_node_make_callback (env: napi_env, async_resource: napi_value, 
       const argVal = $makeGetValue('argv', 'i * ' + POINTER_SIZE, '*')
       arr[i] = emnapiCtx.handleStore.get(argVal)!.value
     }
-    const ret = emnapiNodeBinding.makeCallback(resource, callback, arr, {
+    const ret = emnapiNodeBinding.node.makeCallback(resource, callback, arr, {
       asyncId: async_id,
       triggerAsyncId: trigger_async_id
     })

--- a/packages/emnapi/src/node.ts
+++ b/packages/emnapi/src/node.ts
@@ -1,0 +1,93 @@
+function _emnapi_node_binding_available (): int {
+  return emnapiNodeBinding ? 1 : 0
+}
+
+function _emnapi_node_emit_async_init (
+  async_resource: napi_value,
+  async_resource_name: napi_value,
+  trigger_async_id: double,
+  result: Pointer<[double, double]>
+): void {
+  if (!emnapiNodeBinding) return
+  const resource = emnapiCtx.handleStore.get(async_resource)!.value
+  const resource_name = emnapiCtx.handleStore.get(async_resource_name)!.value
+
+  const asyncContext = emnapiNodeBinding.emitAsyncInit(resource, resource_name, trigger_async_id)
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const asyncId = asyncContext.asyncId; const triggerAsyncId = asyncContext.triggerAsyncId
+  if (result) {
+    $from64('result')
+    $makeSetValue('result', 0, 'asyncId', 'double')
+    $makeSetValue('result', 8, 'triggerAsyncId', 'double')
+  }
+}
+
+function _emnapi_node_emit_async_destroy (async_id: double, trigger_async_id: double): void {
+  if (!emnapiNodeBinding) return
+  emnapiNodeBinding.emitAsyncDestroy({
+    asyncId: async_id,
+    triggerAsyncId: trigger_async_id
+  })
+}
+
+/* function _emnapi_node_open_callback_scope (async_resource: napi_value, async_id: double, trigger_async_id: double, result: Pointer<int64_t>): void {
+  if (!emnapiNodeBinding || !result) return
+  const resource = emnapiCtx.handleStore.get(async_resource)!.value
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const nativeCallbackScopePointer = emnapiNodeBinding.openCallbackScope(resource, {
+    asyncId: async_id,
+    triggerAsyncId: trigger_async_id
+  })
+
+  $from64('result')
+  $makeSetValue('result', 0, 'nativeCallbackScopePointer', 'i64')
+}
+
+function _emnapi_node_close_callback_scope (scope: Pointer<int64_t>): void {
+  if (!emnapiNodeBinding || !scope) return
+  $from64('scope')
+  const nativeCallbackScopePointer = $makeGetValue('scope', 0, 'i64')
+  emnapiNodeBinding.closeCallbackScope(BigInt(nativeCallbackScopePointer))
+} */
+
+// @ts-expect-error
+function _emnapi_node_make_callback (env: napi_env, async_resource: napi_value, cb: napi_value, argv: Pointer<napi_value>, size: size_t, async_id: double, trigger_async_id: double, result: Pointer<napi_value>): napi_status {
+  let i = 0
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  let v: number
+
+  $PREAMBLE!(env, (envObject) => {
+    if (!emnapiNodeBinding) {
+      return envObject.setLastError(napi_status.napi_generic_failure)
+    }
+    const resource = emnapiCtx.handleStore.get(async_resource)!.value
+    const callback = emnapiCtx.handleStore.get(cb)!.value
+    $from64('argv')
+    $from64('size')
+    size = size >>> 0
+    const arr = Array(size)
+    for (; i < size; i++) {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/restrict-plus-operands
+      const argVal = $makeGetValue('argv', 'i * ' + POINTER_SIZE, '*')
+      arr[i] = emnapiCtx.handleStore.get(argVal)!.value
+    }
+    const ret = emnapiNodeBinding.makeCallback(resource, callback, arr, {
+      asyncId: async_id,
+      triggerAsyncId: trigger_async_id
+    })
+    if (result) {
+      $from64('result')
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      v = envObject.ensureHandleId(ret)
+      $makeSetValue('result', 0, 'v', '*')
+    }
+    return envObject.clearLastError()
+  })
+}
+
+emnapiImplement('_emnapi_node_binding_available', 'i', _emnapi_node_binding_available)
+emnapiImplement('_emnapi_node_emit_async_init', 'vppdp', _emnapi_node_emit_async_init)
+emnapiImplement('_emnapi_node_emit_async_destroy', 'vdd', _emnapi_node_emit_async_destroy)
+// emnapiImplement('_emnapi_node_open_callback_scope', 'vpddp', _emnapi_node_open_callback_scope)
+// emnapiImplement('_emnapi_node_close_callback_scope', 'vp', _emnapi_node_close_callback_scope)
+emnapiImplement('_emnapi_node_make_callback', 'ipppppddp', _emnapi_node_make_callback)

--- a/packages/emnapi/src/node.ts
+++ b/packages/emnapi/src/node.ts
@@ -1,7 +1,3 @@
-function _emnapi_node_binding_available (): int {
-  return emnapiNodeBinding ? 1 : 0
-}
-
 function _emnapi_node_emit_async_init (
   async_resource: napi_value,
   async_resource_name: napi_value,
@@ -86,6 +82,10 @@ function _emnapi_node_make_callback (env: napi_env, async_resource: napi_value, 
 }
 
 function _emnapi_async_init_js (async_resource: napi_value, async_resource_name: napi_value, result: Pointer<int64_t>): napi_status {
+  if (!emnapiNodeBinding) {
+    return napi_status.napi_generic_failure
+  }
+
   let resource: object | undefined
 
   if (async_resource) {
@@ -113,6 +113,9 @@ function _emnapi_async_init_js (async_resource: napi_value, async_resource_name:
 }
 
 function _emnapi_async_destroy_js (async_context: Pointer<int64_t>): napi_status {
+  if (!emnapiNodeBinding) {
+    return napi_status.napi_generic_failure
+  }
   $from64('async_context')
   const low = $makeGetValue('async_context', 0, 'i32')
   const high = $makeGetValue('async_context', 4, 'i32')
@@ -177,7 +180,6 @@ function napi_make_callback (env: napi_env, async_context: Pointer<int64_t>, rec
   })
 }
 
-emnapiImplement('_emnapi_node_binding_available', 'i', _emnapi_node_binding_available)
 emnapiImplement('_emnapi_node_emit_async_init', 'vppdp', _emnapi_node_emit_async_init)
 emnapiImplement('_emnapi_node_emit_async_destroy', 'vdd', _emnapi_node_emit_async_destroy)
 // emnapiImplement('_emnapi_node_open_callback_scope', 'vpddp', _emnapi_node_open_callback_scope)

--- a/packages/emnapi/src/thread-safe-function.ts
+++ b/packages/emnapi/src/thread-safe-function.ts
@@ -4,20 +4,4 @@ function _emnapi_call_finalizer (env: napi_env, callback: number, data: number, 
   envObject.callFinalizer(callback, data, hint)
 }
 
-function _emnapi_tsfn_dispatch_one_js (env: number, ref: number, call_js_cb: number, context: number, data: number): void {
-  const envObject = emnapiCtx.envStore.get(env)!
-  const reference = emnapiCtx.refStore.get(ref)
-  const scope = emnapiCtx.openScope(envObject)
-  try {
-    // eslint-disable-next-line @typescript-eslint/prefer-optional-chain, @typescript-eslint/prefer-nullish-coalescing
-    const jsCallback = (reference && reference.get()) || 0
-    envObject.callIntoModule(() => {
-      $makeDynCall('vpppp', 'call_js_cb')(env, jsCallback, context, data)
-    })
-  } finally {
-    emnapiCtx.closeScope(envObject, scope)
-  }
-}
-
 emnapiImplement('_emnapi_call_finalizer', 'vpppp', _emnapi_call_finalizer)
-emnapiImplement('_emnapi_tsfn_dispatch_one_js', 'vppppp', _emnapi_tsfn_dispatch_one_js)

--- a/packages/emnapi/src/typings/emnapi.d.ts
+++ b/packages/emnapi/src/typings/emnapi.d.ts
@@ -2,3 +2,5 @@ declare type Env = import('../../../runtime/lib/typings/index').Env
 declare type Handle<S> = import('../../../runtime/lib/typings/index').Handle<S>
 declare type Context = import('../../../runtime/lib/typings/index').Context
 declare type Reference = import('../../../runtime/lib/typings/index').Reference
+
+declare type NodeBinding = typeof import('../../../node/index')

--- a/packages/node/.gitignore
+++ b/packages/node/.gitignore
@@ -1,0 +1,2 @@
+/build
+/dist

--- a/packages/node/.npmignore
+++ b/packages/node/.npmignore
@@ -1,0 +1,3 @@
+/build
+/dist
+.vscode

--- a/packages/node/.vscode/c_cpp_properties.json
+++ b/packages/node/.vscode/c_cpp_properties.json
@@ -1,0 +1,69 @@
+{
+  "env": {
+    "includePath": [
+      "${default}",
+      "${env:USERPROFILE}/AppData/Local/node-gyp/Cache/16.15.0/include/node"
+    ],
+    "defines": ["NAPI_DISABLE_CPP_EXCEPTIONS", "NODE_ADDON_API_ENABLE_MAYBE"],
+    "clPath": "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Tools\\MSVC\\14.32.31326\\bin\\Hostx64\\x64\\cl.exe",
+    "gccPath": "/usr/bin/gcc",
+    "clangPath": "/usr/bin/clang"
+  },
+  "configurations": [
+    {
+      "name": "Win32",
+      "defines": ["${defines}", "_DEBUG", "UNICODE", "_UNICODE", "_CRT_SECURE_NO_WARNINGS"],
+      "compilerPath": "${clPath}",
+      "windowsSdkVersion": "10.0.19041.0",
+      "intelliSenseMode": "msvc-x64",
+      "cStandard": "c11",
+      "cppStandard": "c++17",
+      "includePath": ["${includePath}"]
+    },
+    {
+      "name": "Linux",
+      "defines": ["${defines}"],
+      "compilerPath": "${gccPath}",
+      "cStandard": "c11",
+      "cppStandard": "c++17",
+      "intelliSenseMode": "gcc-x64",
+      "browse": {
+        "path": [
+          "${workspaceFolder}"
+        ],
+        "limitSymbolsToIncludedHeaders": true,
+        "databaseFilename": ""
+      },
+      "includePath": ["${includePath}"]
+    },
+    {
+      "name": "macOS",
+      "includePath": ["${includePath}"],
+      "defines": ["${defines}"],
+      "macFrameworkPath": ["/System/Library/Frameworks", "/Library/Frameworks"],
+      "compilerPath": "${clangPath}",
+      "cStandard": "c11",
+      "cppStandard": "c++17",
+      "intelliSenseMode": "${default}"
+    },
+    {
+      "name": "Emscripten",
+      "defines": ["${defines}", "__wasm32__", "__EMSCRIPTEN_PTHREADS__", "NAPI_VERSION=8"],
+      "compilerPath": "${env:EMSDK}/upstream/emscripten/emcc",
+      "intelliSenseMode": "linux-clang-x86",
+      "cStandard": "c11",
+      "cppStandard": "c++17",
+      "includePath": ["${includePath}"]
+    },
+    {
+      "name": "Win32 Emscripten",
+      "defines": ["${defines}", "__wasm32__", "__EMSCRIPTEN_PTHREADS__", "NAPI_VERSION=8"],
+      "compilerPath": "${env:EMSDK}\\upstream\\emscripten\\emcc.bat",
+      "intelliSenseMode": "linux-clang-x86",
+      "cStandard": "c11",
+      "cppStandard": "c++17",
+      "includePath": ["${includePath}"]
+    }
+  ],
+  "version": 4
+}

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -1,0 +1,1 @@
+See [https://github.com/toyobayashi/emnapi](https://github.com/toyobayashi/emnapi)

--- a/packages/node/binding.gyp
+++ b/packages/node/binding.gyp
@@ -11,12 +11,18 @@
       ],
     },
     {
+      'target_name': '<(module_name)_napi',
+      'sources': [
+        'src/napi.c',
+      ],
+    },
+    {
       "target_name": "action_after_build",
       "type": "none",
-      "dependencies": [ "<(module_name)" ],
+      "dependencies": [ "<(module_name)", '<(module_name)_napi' ],
       "copies": [
         {
-          "files": [ "<(PRODUCT_DIR)/<(module_name).node" ],
+          "files": [ "<(PRODUCT_DIR)/<(module_name).node", "<(PRODUCT_DIR)/<(module_name)_napi.node" ],
           "destination": "<(module_path)"
         }
       ]

--- a/packages/node/binding.gyp
+++ b/packages/node/binding.gyp
@@ -1,0 +1,25 @@
+{
+  "variables": {
+    "module_name": "emnapi_node_binding",
+    "module_path": "./dist"
+  },
+  'targets': [
+    {
+      'target_name': '<(module_name)',
+      'sources': [
+        'src/binding.cpp',
+      ],
+    },
+    {
+      "target_name": "action_after_build",
+      "type": "none",
+      "dependencies": [ "<(module_name)" ],
+      "copies": [
+        {
+          "files": [ "<(PRODUCT_DIR)/<(module_name).node" ],
+          "destination": "<(module_path)"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/node/index.d.ts
+++ b/packages/node/index.d.ts
@@ -3,8 +3,20 @@ export declare interface AsyncContext {
   triggerAsyncId: number
 }
 
-export declare function emitAsyncInit (resource: object, name: string, triggerAsyncId: number): AsyncContext
-export declare function emitAsyncDestroy (asyncContext: AsyncContext): void
-// export declare function openCallbackScope (resource: object, asyncContext: AsyncContext): bigint
-// export declare function closeCallbackScope (callbackScope: bigint): void
-export declare function makeCallback<P extends any[], T> (resource: object, cb: (...args: P) => T, argv: P, asyncContext: AsyncContext): T
+export declare interface NapiResult<T> {
+  status: number
+  value: T
+}
+
+export declare namespace node {
+  export function emitAsyncInit (resource: object, name: string, triggerAsyncId: number): AsyncContext
+  export function emitAsyncDestroy (asyncContext: AsyncContext): void
+  // export function openCallbackScope (resource: object, asyncContext: AsyncContext): bigint
+  // export function closeCallbackScope (callbackScope: bigint): void
+  export function makeCallback<P extends any[], T> (resource: object, cb: (...args: P) => T, argv: P, asyncContext: AsyncContext): T
+}
+
+export declare namespace napi {
+  export function asyncInit (resource: object, name: string): NapiResult<bigint>
+  export function asyncDestroy (asyncContextPointer: bigint): NapiResult<undefined>
+}

--- a/packages/node/index.d.ts
+++ b/packages/node/index.d.ts
@@ -1,0 +1,10 @@
+export declare interface AsyncContext {
+  asyncId: number
+  triggerAsyncId: number
+}
+
+export declare function emitAsyncInit (resource: object, name: string, triggerAsyncId: number): AsyncContext
+export declare function emitAsyncDestroy (asyncContext: AsyncContext): void
+// export declare function openCallbackScope (resource: object, asyncContext: AsyncContext): bigint
+// export declare function closeCallbackScope (callbackScope: bigint): void
+export declare function makeCallback<P extends any[], T> (resource: object, cb: (...args: P) => T, argv: P, asyncContext: AsyncContext): T

--- a/packages/node/index.d.ts
+++ b/packages/node/index.d.ts
@@ -6,6 +6,7 @@ export declare interface AsyncContext {
 export declare interface NapiResult<T> {
   status: number
   value: T
+  error?: any
 }
 
 export declare namespace node {
@@ -17,6 +18,12 @@ export declare namespace node {
 }
 
 export declare namespace napi {
-  export function asyncInit (resource: object, name: string): NapiResult<bigint>
+  export function asyncInit (resource: object | undefined | null, name: string): NapiResult<bigint>
   export function asyncDestroy (asyncContextPointer: bigint): NapiResult<undefined>
+  export function makeCallback<P extends any[], T> (
+    asyncContextPointer: bigint,
+    recv: any,
+    func: (...args: P) => T,
+    argv: P
+  ): NapiResult<T>
 }

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -1,0 +1,6 @@
+'use strict'
+Object.defineProperty(exports, '__esModule', { value: true })
+
+const emnapiNodeBinding = require('./dist/emnapi_node_binding.node')
+
+module.exports = emnapiNodeBinding

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -1,6 +1,6 @@
 'use strict'
 
 module.exports = {
-  ...require('./dist/emnapi_node_binding.node')/* ,
-  ...require('./dist/emnapi_node_binding_napi.node') */
+  node: require('./dist/emnapi_node_binding.node'),
+  napi: require('./dist/emnapi_node_binding_napi.node')
 }

--- a/packages/node/index.js
+++ b/packages/node/index.js
@@ -1,6 +1,6 @@
 'use strict'
-Object.defineProperty(exports, '__esModule', { value: true })
 
-const emnapiNodeBinding = require('./dist/emnapi_node_binding.node')
-
-module.exports = emnapiNodeBinding
+module.exports = {
+  ...require('./dist/emnapi_node_binding.node')/* ,
+  ...require('./dist/emnapi_node_binding_napi.node') */
+}

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@tybys/emnapi-node-binding",
+  "version": "0.28.0",
+  "description": "Bridge connecting emnapi and Node.js native implementation",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "scripts": {
+    "build": "node-gyp rebuild"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/toyobayashi/emnapi.git"
+  },
+  "author": "toyobayashi",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/toyobayashi/emnapi/issues"
+  },
+  "homepage": "https://github.com/toyobayashi/emnapi#readme",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/node/src/binding.cpp
+++ b/packages/node/src/binding.cpp
@@ -1,0 +1,98 @@
+#include <vector>
+#include <node.h>
+
+namespace emnapi_node_binding {
+
+namespace {
+
+void EmitAsyncInit(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  v8::Isolate* isolate = args.GetIsolate();
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
+  v8::Local<v8::Object> resource = args[0].As<v8::Object>();
+  v8::Local<v8::String> name = args[1].As<v8::String>();
+  double trigger_async_id = args[2].As<v8::Number>()->Value();
+
+  node::async_context result_context = node::EmitAsyncInit(isolate, resource, name, trigger_async_id);
+
+  v8::Local<v8::Object> result = v8::Object::New(isolate);
+  v8::Local<v8::String> async_id_key = v8::String::NewFromUtf8(isolate, "asyncId").ToLocalChecked();
+  v8::Local<v8::String> trigger_async_id_key = v8::String::NewFromUtf8(isolate, "triggerAsyncId").ToLocalChecked();
+  v8::Local<v8::Number> result_async_id = v8::Number::New(isolate, result_context.async_id);
+  v8::Local<v8::Number> result_trigger_async_id = v8::Number::New(isolate, result_context.trigger_async_id);
+  result->Set(context, async_id_key, result_async_id).ToChecked();
+  result->Set(context, trigger_async_id_key, result_trigger_async_id).ToChecked();
+
+  args.GetReturnValue().Set(result);
+}
+
+inline node::async_context FromAsyncContextObject(v8::Isolate* isolate,
+                                                  v8::Local<v8::Object> async_context_object) {
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
+  double async_id = async_context_object
+    ->Get(context, v8::String::NewFromUtf8(isolate, "asyncId").ToLocalChecked()).ToLocalChecked()
+    .As<v8::Number>()->Value();
+  double trigger_async_id = async_context_object
+    ->Get(context, v8::String::NewFromUtf8(isolate, "triggerAsyncId").ToLocalChecked()).ToLocalChecked()
+    .As<v8::Number>()->Value();
+  
+  return { async_id, trigger_async_id };
+}
+
+void EmitAsyncDestroy(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  v8::Isolate* isolate = args.GetIsolate();
+  v8::Local<v8::Object> async_context_object = args[0].As<v8::Object>();
+  node::EmitAsyncDestroy(isolate, FromAsyncContextObject(isolate, async_context_object));
+  args.GetReturnValue().Set(v8::Undefined(isolate));
+}
+
+/* void OpenCallbackScope(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  v8::Isolate* isolate = args.GetIsolate();
+  v8::Local<v8::Object> resource = args[0].As<v8::Object>();
+  v8::Local<v8::Object> async_context_object = args[1].As<v8::Object>();
+
+  node::CallbackScope* callback_scope = new node::CallbackScope(
+      isolate, resource, FromAsyncContextObject(isolate, async_context_object));
+
+  args.GetReturnValue().Set(v8::BigInt::New(isolate, reinterpret_cast<int64_t>(callback_scope)));
+}
+
+void CloseCallbackScope(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  v8::Isolate* isolate = args.GetIsolate();
+  v8::Local<v8::BigInt> scope = args[0].As<v8::BigInt>();
+
+  node::CallbackScope* callback_scope = reinterpret_cast<node::CallbackScope*>(scope->Int64Value());
+  delete callback_scope;
+
+  args.GetReturnValue().Set(v8::Undefined(isolate));
+} */
+
+void MakeCallback(const v8::FunctionCallbackInfo<v8::Value>& args) {
+  v8::Isolate* isolate = args.GetIsolate();
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
+  v8::Local<v8::Object> resource = args[0].As<v8::Object>();
+  v8::Local<v8::Function> cb = args[1].As<v8::Function>();
+  v8::Local<v8::Array> argv = args[2].As<v8::Array>();
+  v8::Local<v8::Object> async_context_object = args[3].As<v8::Object>();
+
+  uint32_t argc = argv->Length();
+  std::vector<v8::Local<v8::Value>> vec_argv(argc);
+  for (uint32_t i = 0; i < argc; ++i) {
+    vec_argv[i] = argv->Get(context, i).ToLocalChecked();
+  }
+
+  v8::MaybeLocal<v8::Value> ret = node::MakeCallback(isolate, resource, cb, argc, vec_argv.data(), FromAsyncContextObject(isolate, async_context_object));
+
+  args.GetReturnValue().Set(ret.FromMaybe(v8::Local<v8::Value>()));
+}
+
+}
+
+NODE_MODULE_INIT() {
+  NODE_SET_METHOD(exports, "emitAsyncInit", EmitAsyncInit);
+  NODE_SET_METHOD(exports, "emitAsyncDestroy", EmitAsyncDestroy);
+  // NODE_SET_METHOD(exports, "openCallbackScope", OpenCallbackScope);
+  // NODE_SET_METHOD(exports, "closeCallbackScope", CloseCallbackScope);
+  NODE_SET_METHOD(exports, "makeCallback", MakeCallback);
+}
+
+}

--- a/packages/node/src/napi.c
+++ b/packages/node/src/napi.c
@@ -1,0 +1,70 @@
+#include <assert.h>
+#include <node_api.h>
+
+#define NAPI_ASSERT(call) assert(napi_ok == (call))
+
+static napi_value napi_async_init_js(napi_env env, napi_callback_info info) {
+  napi_value argv[2];
+  size_t argc = 2;
+  napi_async_context ctx;
+  napi_value ret;
+  napi_status status;
+  napi_value status_value, ret_value;
+  NAPI_ASSERT(napi_get_cb_info(env, info, &argc, argv, NULL, NULL));
+  status = napi_async_init(env, argv[0], argv[1], &ctx);
+  NAPI_ASSERT(napi_create_object(env, &ret));
+  NAPI_ASSERT(napi_create_int32(env, status, &status_value));
+  NAPI_ASSERT(napi_create_bigint_int64(env, (int64_t) ctx, &ret_value));
+  NAPI_ASSERT(napi_set_named_property(env, ret, "status", status_value));
+  NAPI_ASSERT(napi_set_named_property(env, ret, "value", ret_value));
+  return ret;
+}
+
+static napi_value napi_async_destroy_js(napi_env env, napi_callback_info info) {
+  napi_value argv[1];
+  size_t argc = 1;
+  int64_t ctx;
+  napi_value ret;
+  napi_status status;
+  napi_value status_value, ret_value;
+  bool lossless;
+  NAPI_ASSERT(napi_get_cb_info(env, info, &argc, argv, NULL, NULL));
+  NAPI_ASSERT(napi_get_value_bigint_int64(env, *argv, &ctx, &lossless));
+  status = napi_async_destroy(env, (napi_async_context) ctx);
+  NAPI_ASSERT(napi_create_object(env, &ret));
+  NAPI_ASSERT(napi_create_int32(env, status, &status_value));
+  NAPI_ASSERT(napi_get_undefined(env, &ret_value));
+  NAPI_ASSERT(napi_set_named_property(env, ret, "status", status_value));
+  NAPI_ASSERT(napi_set_named_property(env, ret, "value", ret_value));
+  return ret;
+}
+
+/* static napi_value napi_open_callback_scope_js(napi_env env, napi_callback_info info) {
+  napi_value argv[2];
+  size_t argc = 2;
+  napi_get_cb_info(env, info, &argc, argv, NULL, NULL);
+  bool lossless;
+  int64_t ctx;
+  napi_get_value_bigint_int64(env, argv[1], &ctx, &lossless);
+  napi_callback_scope scope;
+  napi_open_callback_scope(env, argv[0], (napi_async_context) ctx, &scope);
+  napi_value ret;
+  napi_create_bigint_int64(env, (int64_t) scope, &ret);
+  return ret;
+} */
+
+NAPI_MODULE_INIT() {
+  napi_value ai;
+  NAPI_ASSERT(napi_create_function(env, "asyncInit", NAPI_AUTO_LENGTH, napi_async_init_js, NULL, &ai));
+  NAPI_ASSERT(napi_set_named_property(env, exports, "asyncInit", ai));
+
+  napi_value ad;
+  NAPI_ASSERT(napi_create_function(env, "asyncDestroy", NAPI_AUTO_LENGTH, napi_async_destroy_js, NULL, &ad));
+  NAPI_ASSERT(napi_set_named_property(env, exports, "asyncDestroy", ad));
+
+  /* napi_value ocs;
+  napi_create_function(env, "napiOpenCallbackScope", NAPI_AUTO_LENGTH, napi_open_callback_scope_js, NULL, &ocs);
+  napi_set_named_property(env, exports, "napiOpenCallbackScope", ocs); */
+
+  return exports;
+}

--- a/packages/node/src/napi.c
+++ b/packages/node/src/napi.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <stdlib.h>
 #include <node_api.h>
 
 #define NAPI_ASSERT(call) assert(napi_ok == (call))
@@ -10,8 +11,14 @@ static napi_value napi_async_init_js(napi_env env, napi_callback_info info) {
   napi_value ret;
   napi_status status;
   napi_value status_value, ret_value;
+  napi_valuetype type;
+  napi_value resource = NULL;
   NAPI_ASSERT(napi_get_cb_info(env, info, &argc, argv, NULL, NULL));
-  status = napi_async_init(env, argv[0], argv[1], &ctx);
+  NAPI_ASSERT(napi_typeof(env, argv[0], &type));
+  if (type != napi_undefined && type != napi_null) {
+    resource = argv[0];
+  }
+  status = napi_async_init(env, resource, argv[1], &ctx);
   NAPI_ASSERT(napi_create_object(env, &ret));
   NAPI_ASSERT(napi_create_int32(env, status, &status_value));
   NAPI_ASSERT(napi_create_bigint_int64(env, (int64_t) ctx, &ret_value));
@@ -39,6 +46,51 @@ static napi_value napi_async_destroy_js(napi_env env, napi_callback_info info) {
   return ret;
 }
 
+static napi_value napi_make_callback_js(napi_env env, napi_callback_info info) {
+  napi_value argv[4];
+  size_t argc = 4;
+  int64_t ctx = 0;
+  napi_value ret;
+  napi_status status;
+  napi_value status_value, ret_value;
+  bool lossless;
+  napi_value arr;
+  uint32_t len = 0;
+  napi_value* callback_argv = NULL;
+  napi_value err = NULL;
+
+  NAPI_ASSERT(napi_get_cb_info(env, info, &argc, argv, NULL, NULL));
+  NAPI_ASSERT(napi_get_value_bigint_int64(env, *argv, &ctx, &lossless));
+  arr = argv[3];
+  NAPI_ASSERT(napi_get_array_length(env, arr, &len));
+  if (len != 0) {
+    callback_argv = (napi_value*) malloc(len * sizeof(napi_value));
+  } 
+  for (uint32_t i = 0; i < len; ++i) {
+    NAPI_ASSERT(napi_get_element(env, arr, i, callback_argv + i));
+  }
+  NAPI_ASSERT(napi_get_and_clear_last_exception(env, &err));
+  err = NULL;
+  status = napi_make_callback(env, (napi_async_context) ctx, argv[1], argv[2], len, callback_argv, &ret_value);
+  if (callback_argv != NULL) {
+    free(callback_argv);
+  }
+  if (status == napi_pending_exception) {
+    NAPI_ASSERT(napi_get_and_clear_last_exception(env, &err));
+  }
+  NAPI_ASSERT(napi_create_object(env, &ret));
+  NAPI_ASSERT(napi_create_int32(env, status, &status_value));
+  NAPI_ASSERT(napi_set_named_property(env, ret, "status", status_value));
+  if (err != NULL) {
+    NAPI_ASSERT(napi_get_undefined(env, &ret_value));
+    NAPI_ASSERT(napi_set_named_property(env, ret, "value", ret_value));
+    NAPI_ASSERT(napi_set_named_property(env, ret, "error", err));
+  } else {
+    NAPI_ASSERT(napi_set_named_property(env, ret, "value", ret_value));
+  }
+  return ret;
+}
+
 /* static napi_value napi_open_callback_scope_js(napi_env env, napi_callback_info info) {
   napi_value argv[2];
   size_t argc = 2;
@@ -61,6 +113,10 @@ NAPI_MODULE_INIT() {
   napi_value ad;
   NAPI_ASSERT(napi_create_function(env, "asyncDestroy", NAPI_AUTO_LENGTH, napi_async_destroy_js, NULL, &ad));
   NAPI_ASSERT(napi_set_named_property(env, exports, "asyncDestroy", ad));
+
+  napi_value mc;
+  NAPI_ASSERT(napi_create_function(env, "makeCallback", NAPI_AUTO_LENGTH, napi_make_callback_js, NULL, &mc));
+  NAPI_ASSERT(napi_set_named_property(env, exports, "makeCallback", mc));
 
   /* napi_value ocs;
   napi_create_function(env, "napiOpenCallbackScope", NAPI_AUTO_LENGTH, napi_open_callback_scope_js, NULL, &ocs);

--- a/packages/test/async/async_hooks.test.js
+++ b/packages/test/async/async_hooks.test.js
@@ -1,0 +1,77 @@
+/* eslint-disable camelcase */
+'use strict'
+const { load } = require('../util')
+const common = require('../common')
+const assert = require('assert')
+const async_hooks = require('async_hooks')
+
+module.exports = load('async', { nodeBinding: require('@tybys/emnapi-node-binding') }).then(test_async => {
+  return new Promise((resolve, reject) => {
+    const events = []
+    let testId
+    const initAsyncId = async_hooks.executionAsyncId()
+
+    async_hooks.createHook({
+      init (id, provider, triggerAsyncId, resource) {
+        if (provider === 'TestResource') {
+          testId = id
+          events.push({ type: 'init', id, provider, triggerAsyncId, resource })
+        }
+      },
+      before (id) {
+        if (testId === id) {
+          events.push({ type: 'before', id })
+        }
+      },
+      after (id) {
+        if (testId === id) {
+          events.push({ type: 'after', id })
+        }
+      },
+      destroy (id) {
+        if (testId === id) {
+          events.push({ type: 'destroy', id })
+        }
+      }
+    }).enable()
+
+    const resource = { foo: 'foo' }
+
+    events.push({ type: 'start' })
+    test_async.Test(5, resource, common.mustCall(function (err, val) {
+      try {
+        assert.strictEqual(err, null)
+        assert.strictEqual(val, 10)
+        events.push({ type: 'complete' })
+        process.nextTick(common.mustCall())
+      } catch (err) {
+        reject(err)
+      }
+    }))
+    events.push({ type: 'scheduled' })
+
+    process.on('exit', () => {
+      try {
+        assert.deepStrictEqual(events, [
+          { type: 'start' },
+          {
+            type: 'init',
+            id: testId,
+            provider: 'TestResource',
+            triggerAsyncId: initAsyncId,
+            resource
+          },
+          { type: 'scheduled' },
+          { type: 'before', id: testId },
+          { type: 'complete' },
+          { type: 'after', id: testId },
+          { type: 'destroy', id: testId }
+        ])
+      } catch (err) {
+        reject(err)
+        return
+      }
+      resolve()
+    })
+  })
+})

--- a/packages/test/async_context/ac.test.js
+++ b/packages/test/async_context/ac.test.js
@@ -1,0 +1,67 @@
+/* eslint-disable camelcase */
+'use strict'
+// Flags: --gc-interval=100 --gc-global
+
+const assert = require('assert')
+const async_hooks = require('async_hooks')
+const { load } = require('../util')
+
+module.exports = load('async_context', { nodeBinding: require('@tybys/emnapi-node-binding') }).then(binding => {
+  const {
+    makeCallback,
+    createAsyncResource,
+    destroyAsyncResource
+  } = binding
+
+  const hook_result = {
+    id: null,
+    resource: null,
+    init_called: false,
+    destroy_called: false
+  }
+
+  const test_hook = async_hooks.createHook({
+    init: (id, type, triggerAsyncId, resource) => {
+      if (type === 'test_async') {
+        hook_result.id = id
+        hook_result.init_called = true
+        hook_result.resource = resource
+      }
+    },
+    destroy: (id) => {
+      if (id === hook_result.id) hook_result.destroy_called = true
+    }
+  })
+
+  test_hook.enable()
+  const resourceWrap = createAsyncResource(
+    /**
+     * set resource to NULL to generate a managed resource object
+     */
+    undefined
+  )
+
+  assert.strictEqual(hook_result.destroy_called, false)
+  const recv = {}
+  makeCallback(resourceWrap, recv, function callback () {
+    assert.strictEqual(hook_result.destroy_called, false)
+    assert.strictEqual(
+      hook_result.resource,
+      async_hooks.executionAsyncResource()
+    )
+    assert.strictEqual(this, recv)
+
+    setImmediate(() => {
+      assert.strictEqual(hook_result.destroy_called, false)
+      assert.notStrictEqual(
+        hook_result.resource,
+        async_hooks.executionAsyncResource()
+      )
+
+      destroyAsyncResource(resourceWrap)
+      setImmediate(() => {
+        assert.strictEqual(hook_result.destroy_called, true)
+      })
+    })
+  })
+})

--- a/packages/test/async_context/binding.c
+++ b/packages/test/async_context/binding.c
@@ -1,0 +1,131 @@
+#include <node_api.h>
+#include <assert.h>
+#include <stdio.h>
+#include "../common.h"
+
+#define MAX_ARGUMENTS 10
+#define RESERVED_ARGS 3
+
+static napi_value MakeCallback(napi_env env, napi_callback_info info) {
+  size_t argc = MAX_ARGUMENTS;
+  size_t n;
+  napi_value args[MAX_ARGUMENTS];
+  // NOLINTNEXTLINE (readability/null_usage)
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  NAPI_ASSERT(env, argc > 0, "Wrong number of arguments");
+
+  napi_value async_context_wrap = args[0];
+  napi_value recv = args[1];
+  napi_value func = args[2];
+
+  napi_value argv[MAX_ARGUMENTS - RESERVED_ARGS];
+  for (n = RESERVED_ARGS; n < argc; n += 1) {
+    argv[n - RESERVED_ARGS] = args[n];
+  }
+
+  napi_valuetype func_type;
+  NAPI_CALL(env, napi_typeof(env, func, &func_type));
+
+  napi_async_context context;
+  NAPI_CALL(env, napi_unwrap(env, async_context_wrap, (void**)&context));
+
+  napi_value result;
+  if (func_type == napi_function) {
+    NAPI_CALL(env, napi_make_callback(
+        env, context, recv, func, argc - RESERVED_ARGS, argv, &result));
+  } else {
+    NAPI_ASSERT(env, false, "Unexpected argument type");
+  }
+
+  return result;
+}
+
+static void AsyncDestroyCb(napi_env env, void* data, void* hint) {
+  printf("AsyncDestroyCb\n");
+  napi_status status = napi_async_destroy(env, (napi_async_context)data);
+  // We cannot use NAPI_ASSERT_RETURN_VOID because we need to have a JS
+  // stack below in order to use exceptions.
+  assert(status == napi_ok);
+}
+
+#define CREATE_ASYNC_RESOURCE_ARGC 2
+
+static napi_value CreateAsyncResource(napi_env env, napi_callback_info info) {
+  napi_value async_context_wrap;
+  NAPI_CALL(env, napi_create_object(env, &async_context_wrap));
+
+  size_t argc = CREATE_ASYNC_RESOURCE_ARGC;
+  napi_value args[CREATE_ASYNC_RESOURCE_ARGC];
+  // NOLINTNEXTLINE (readability/null_usage)
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  napi_value resource = args[0];
+  napi_value js_destroy_on_finalizer = args[1];
+  napi_valuetype resource_type;
+  NAPI_CALL(env, napi_typeof(env, resource, &resource_type));
+  if (resource_type != napi_object) {
+    resource = NULL;
+  }
+
+  napi_value resource_name;
+  NAPI_CALL(env, napi_create_string_utf8(
+      env, "test_async", NAPI_AUTO_LENGTH, &resource_name));
+
+  napi_async_context context;
+  NAPI_CALL(env, napi_async_init(env, resource, resource_name, &context));
+
+  bool destroy_on_finalizer = true;
+  if (argc == 2) {
+    NAPI_CALL(env, napi_get_value_bool(env, js_destroy_on_finalizer, &destroy_on_finalizer));
+  }
+  if (resource_type == napi_object && destroy_on_finalizer) {
+    NAPI_CALL(env, napi_add_finalizer(
+        env, resource, (void*)context, AsyncDestroyCb, NULL, NULL));
+  }
+  NAPI_CALL(env, napi_wrap(env, async_context_wrap, context, NULL, NULL, NULL));
+  return async_context_wrap;
+}
+
+#define DESTROY_ASYNC_RESOURCE_ARGC 1
+
+static napi_value DestroyAsyncResource(napi_env env, napi_callback_info info) {
+  size_t argc = DESTROY_ASYNC_RESOURCE_ARGC;
+  napi_value args[DESTROY_ASYNC_RESOURCE_ARGC];
+  // NOLINTNEXTLINE (readability/null_usage)
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+  NAPI_ASSERT(env, argc == 1, "Wrong number of arguments");
+
+  napi_value async_context_wrap = args[0];
+
+  napi_async_context async_context;
+  NAPI_CALL(env,
+            napi_remove_wrap(env, async_context_wrap, (void**)&async_context));
+  NAPI_CALL(env, napi_async_destroy(env, async_context));
+
+  return async_context_wrap;
+}
+
+static
+napi_value Init(napi_env env, napi_value exports) {
+  napi_value fn;
+  NAPI_CALL(env, napi_create_function(
+      // NOLINTNEXTLINE (readability/null_usage)
+      env, NULL, NAPI_AUTO_LENGTH, MakeCallback, NULL, &fn));
+  NAPI_CALL(env, napi_set_named_property(env, exports, "makeCallback", fn));
+  NAPI_CALL(env, napi_create_function(
+      // NOLINTNEXTLINE (readability/null_usage)
+      env, NULL, NAPI_AUTO_LENGTH, CreateAsyncResource, NULL, &fn));
+  NAPI_CALL(env, napi_set_named_property(
+      env, exports, "createAsyncResource", fn));
+
+  NAPI_CALL(env, napi_create_function(
+      // NOLINTNEXTLINE (readability/null_usage)
+      env, NULL, NAPI_AUTO_LENGTH, DestroyAsyncResource, NULL, &fn));
+  NAPI_CALL(env, napi_set_named_property(
+      env, exports, "destroyAsyncResource", fn));
+
+  return exports;
+}
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/packages/test/async_context/gcable-callback.test.js
+++ b/packages/test/async_context/gcable-callback.test.js
@@ -1,0 +1,80 @@
+/* eslint-disable camelcase */
+'use strict'
+// Flags: --gc-interval=100 --gc-global
+
+const assert = require('assert')
+const async_hooks = require('async_hooks')
+const { load } = require('../util')
+
+module.exports = load('async_context', { nodeBinding: require('@tybys/emnapi-node-binding') }).then(binding => {
+  return new Promise((resolve, reject) => {
+    const {
+      createAsyncResource,
+      destroyAsyncResource,
+      makeCallback
+    } = binding
+
+    // Test for https://github.com/nodejs/node/issues/27218:
+    // napi_async_destroy() can be called during a regular garbage collection run.
+
+    const hook_result = {
+      id: null,
+      init_called: false,
+      destroy_called: false
+    }
+
+    const test_hook = async_hooks.createHook({
+      init: (id, type) => {
+        if (type === 'test_async') {
+          hook_result.id = id
+          hook_result.init_called = true
+        }
+      },
+      destroy: (id) => {
+        if (id === hook_result.id) hook_result.destroy_called = true
+      }
+    })
+
+    test_hook.enable()
+    const asyncResource = createAsyncResource(
+      { foo: 'bar' },
+      /* destroy_on_finalizer */false
+    )
+
+    // Trigger GC. This does *not* use global.gc(), because what we want to verify
+    // is that `napi_async_destroy()` can be called when there is no JS context
+    // on the stack at the time of GC.
+    // Currently, using --gc-interval=100 + 1M elements seems to work fine for this.
+    const arr = new Array(1024 * 1024)
+    for (let i = 0; i < arr.length; i++) { arr[i] = {} }
+
+    assert.strictEqual(hook_result.destroy_called, false)
+    setImmediate(() => {
+      try {
+        assert.strictEqual(hook_result.destroy_called, false)
+        makeCallback(asyncResource, process, () => {
+          const executionAsyncResource = async_hooks.executionAsyncResource()
+          // Assuming the executionAsyncResource was created for the absence of the
+          // initial `{ foo: 'bar' }`.
+          // This is the worst path of `napi_async_context` related API of
+          // recovering from the condition and not break the executionAsyncResource
+          // shape, although the executionAsyncResource might not be correct.
+          assert.strictEqual(typeof executionAsyncResource, 'object')
+          assert.strictEqual(executionAsyncResource.foo, undefined)
+          destroyAsyncResource(asyncResource)
+          setImmediate(() => {
+            try {
+              assert.strictEqual(hook_result.destroy_called, true)
+            } catch (err) {
+              reject(err)
+              return
+            }
+            resolve()
+          })
+        })
+      } catch (err) {
+        reject(err)
+      }
+    })
+  })
+})

--- a/packages/test/async_context/gcable.test.js
+++ b/packages/test/async_context/gcable.test.js
@@ -1,0 +1,50 @@
+/* eslint-disable camelcase */
+'use strict'
+// Flags: --gc-interval=100 --gc-global
+
+const assert = require('assert')
+const async_hooks = require('async_hooks')
+const common = require('../common')
+
+const { load } = require('../util')
+
+module.exports = load('async_context', { nodeBinding: require('@tybys/emnapi-node-binding') }).then(binding => {
+  const { createAsyncResource } = binding
+
+  // Test for https://github.com/nodejs/node/issues/27218:
+  // napi_async_destroy() can be called during a regular garbage collection run.
+
+  const hook_result = {
+    id: null,
+    init_called: false,
+    destroy_called: false
+  }
+
+  const test_hook = async_hooks.createHook({
+    init: (id, type) => {
+      if (type === 'test_async') {
+        hook_result.id = id
+        hook_result.init_called = true
+      }
+    },
+    destroy: (id) => {
+      if (id === hook_result.id) hook_result.destroy_called = true
+    }
+  })
+
+  test_hook.enable()
+  createAsyncResource({})
+
+  // Trigger GC. This does *not* use global.gc(), because what we want to verify
+  // is that `napi_async_destroy()` can be called when there is no JS context
+  // on the stack at the time of GC.
+  // Currently, using --gc-interval=100 + 1M elements seems to work fine for this.
+  const arr = new Array(1024 * 1024)
+  for (let i = 0; i < arr.length; i++) { arr[i] = {} }
+
+  assert.strictEqual(hook_result.destroy_called, false)
+  return common.gcUntil('hook_result.destroy_called', () => hook_result.destroy_called)
+    .then(() => {
+      assert.strictEqual(hook_result.destroy_called, true)
+    })
+})

--- a/packages/test/cgen.config.js
+++ b/packages/test/cgen.config.js
@@ -168,6 +168,7 @@ module.exports = function (_options, { isDebug, isEmscripten }) {
       ...(isEmscripten ? [createTarget('emnapitest', ['./emnapitest/binding.c'], true, false, ['-sEXPORTED_RUNTIME_METHODS=[\'emnapiSyncMemory\']'])] : []),
       createTarget('version', ['./version/binding.c']),
       createTarget('make_callback', ['./make_callback/binding.c'], false),
+      createTarget('async_context', ['./async_context/binding.c'], false),
 
       ...(!(isEmscripten && process.env.MEMORY64)
         ? [

--- a/packages/test/cgen.config.js
+++ b/packages/test/cgen.config.js
@@ -167,6 +167,7 @@ module.exports = function (_options, { isDebug, isEmscripten }) {
       createTarget('cleanup_hook', ['./cleanup_hook/binding.c'], false),
       ...(isEmscripten ? [createTarget('emnapitest', ['./emnapitest/binding.c'], true, false, ['-sEXPORTED_RUNTIME_METHODS=[\'emnapiSyncMemory\']'])] : []),
       createTarget('version', ['./version/binding.c']),
+      createTarget('make_callback', ['./make_callback/binding.c'], false),
 
       ...(!(isEmscripten && process.env.MEMORY64)
         ? [

--- a/packages/test/make_callback/binding.c
+++ b/packages/test/make_callback/binding.c
@@ -1,0 +1,60 @@
+#include <node_api.h>
+#include <assert.h>
+#include "../common.h"
+
+#define MAX_ARGUMENTS 10
+#define RESERVED_ARGS 3
+
+static napi_value MakeCallback(napi_env env, napi_callback_info info) {
+  size_t argc = MAX_ARGUMENTS;
+  size_t n;
+  napi_value args[MAX_ARGUMENTS];
+  // NOLINTNEXTLINE (readability/null_usage)
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  NAPI_ASSERT(env, argc > 0, "Wrong number of arguments");
+
+  napi_value resource = args[0];
+  napi_value recv = args[1];
+  napi_value func = args[2];
+
+  napi_value argv[MAX_ARGUMENTS - RESERVED_ARGS];
+  for (n = RESERVED_ARGS; n < argc; n += 1) {
+    argv[n - RESERVED_ARGS] = args[n];
+  }
+
+  napi_valuetype func_type;
+
+  NAPI_CALL(env, napi_typeof(env, func, &func_type));
+
+  napi_value resource_name;
+  NAPI_CALL(env, napi_create_string_utf8(
+      env, "test", NAPI_AUTO_LENGTH, &resource_name));
+
+  napi_async_context context;
+  NAPI_CALL(env, napi_async_init(env, resource, resource_name, &context));
+
+  napi_value result;
+  if (func_type == napi_function) {
+    NAPI_CALL(env, napi_make_callback(
+        env, context, recv, func, argc - RESERVED_ARGS, argv, &result));
+  } else {
+    NAPI_ASSERT(env, false, "Unexpected argument type");
+  }
+
+  NAPI_CALL(env, napi_async_destroy(env, context));
+
+  return result;
+}
+
+static
+napi_value Init(napi_env env, napi_value exports) {
+  napi_value fn;
+  NAPI_CALL(env, napi_create_function(
+      // NOLINTNEXTLINE (readability/null_usage)
+      env, NULL, NAPI_AUTO_LENGTH, MakeCallback, NULL, &fn));
+  NAPI_CALL(env, napi_set_named_property(env, exports, "makeCallback", fn));
+  return exports;
+}
+
+NAPI_MODULE(NODE_GYP_MODULE_NAME, Init)

--- a/packages/test/make_callback/make_callback.test.js
+++ b/packages/test/make_callback/make_callback.test.js
@@ -1,0 +1,86 @@
+'use strict'
+const assert = require('assert')
+const { load } = require('../util')
+const common = require('../common')
+const vm = require('vm')
+
+module.exports = load('make_callback', { nodeBinding: require('@tybys/emnapi-node-binding') }).then(binding => {
+  const makeCallback = binding.makeCallback
+
+  function myMultiArgFunc (arg1, arg2, arg3) {
+    assert.strictEqual(arg1, 1)
+    assert.strictEqual(arg2, 2)
+    assert.strictEqual(arg3, 3)
+    return 42
+  }
+
+  /**
+ * Resource should be able to be arbitrary objects without special internal
+ * slots. Testing with plain object here.
+ */
+  const resource = {}
+  assert.strictEqual(makeCallback(resource, process, common.mustCall(function () {
+    assert.strictEqual(arguments.length, 0)
+    assert.strictEqual(this, process)
+    return 42
+  })), 42)
+
+  assert.strictEqual(makeCallback(resource, process, common.mustCall(function (x) {
+    assert.strictEqual(arguments.length, 1)
+    assert.strictEqual(this, process)
+    assert.strictEqual(x, 1337)
+    return 42
+  }), 1337), 42)
+
+  assert.strictEqual(makeCallback(resource, this,
+    common.mustCall(myMultiArgFunc), 1, 2, 3), 42)
+
+  // TODO(node-api): napi_make_callback needs to support
+  // strings passed for the func argument
+  //
+  // const recv = {
+  //   one: common.mustCall(function() {
+  //     assert.strictEqual(0, arguments.length);
+  //     assert.strictEqual(this, recv);
+  //     return 42;
+  //   }),
+  //   two: common.mustCall(function(x) {
+  //     assert.strictEqual(1, arguments.length);
+  //     assert.strictEqual(this, recv);
+  //     assert.strictEqual(x, 1337);
+  //     return 42;
+  //   }),
+  // };
+  //
+  // assert.strictEqual(makeCallback(recv, 'one'), 42);
+  // assert.strictEqual(makeCallback(recv, 'two', 1337), 42);
+  //
+  // // Check that callbacks on a receiver from a different context works.
+  // const foreignObject = vm.runInNewContext('({ fortytwo() { return 42; } })');
+  // assert.strictEqual(makeCallback(foreignObject, 'fortytwo'), 42);
+
+  // Check that the callback is made in the context of the receiver.
+  const target = vm.runInNewContext(`
+    (function($Object) {
+      if (Object === $Object)
+        throw new Error('bad');
+      return Object;
+    })
+`)
+  assert.notStrictEqual(makeCallback(resource, process, target, Object), Object)
+
+  // Runs in inner context.
+  const forward = vm.runInNewContext(`
+    (function(forward) {
+      return forward(Object);
+    })
+`)
+
+  // Runs in outer context.
+  function endpoint ($Object) {
+    if (Object === $Object) { throw new Error('bad') }
+    return Object
+  }
+
+  assert.strictEqual(makeCallback(resource, process, forward, endpoint), Object)
+})

--- a/packages/test/make_callback/make_callback_hooks.test.js
+++ b/packages/test/make_callback/make_callback_hooks.test.js
@@ -1,0 +1,72 @@
+/* eslint-disable camelcase */
+'use strict'
+const assert = require('assert')
+const { load } = require('../util')
+const async_hooks = require('async_hooks')
+
+module.exports = load('make_callback', { nodeBinding: require('@tybys/emnapi-node-binding') }).then(async binding => {
+  const makeCallback = binding.makeCallback
+
+  // Check async hooks integration using async context.
+  const hook_result = {
+    id: null,
+    init_called: false,
+    before_called: false,
+    after_called: false,
+    destroy_called: false
+  }
+  const test_hook = async_hooks.createHook({
+    init: (id, type) => {
+      if (type === 'test') {
+        hook_result.id = id
+        hook_result.init_called = true
+      }
+    },
+    before: (id) => {
+      if (id === hook_result.id) hook_result.before_called = true
+    },
+    after: (id) => {
+      if (id === hook_result.id) hook_result.after_called = true
+    },
+    destroy: (id) => {
+      if (id === hook_result.id) hook_result.destroy_called = true
+    }
+  })
+
+  test_hook.enable()
+
+  await new Promise((resolve, reject) => {
+    /**
+     * Resource should be able to be arbitrary objects without special internal
+     * slots. Testing with plain object here.
+     */
+    const resource = {}
+    makeCallback(resource, process, function cb () {
+      try {
+        assert.strictEqual(this, process)
+        assert.strictEqual(async_hooks.executionAsyncResource(), resource)
+      } catch (err) {
+        reject(err)
+        return
+      }
+      resolve()
+    })
+  })
+
+  assert.strictEqual(hook_result.init_called, true)
+  assert.strictEqual(hook_result.before_called, true)
+  assert.strictEqual(hook_result.after_called, true)
+  await new Promise((resolve, reject) => {
+    setImmediate(() => {
+      try {
+        assert.strictEqual(hook_result.destroy_called, true)
+      } catch (err) {
+        reject(err)
+        return
+      } finally {
+        test_hook.disable()
+      }
+      resolve()
+    })
+  })
+})

--- a/packages/test/node-addon-api/async_worker.test.js
+++ b/packages/test/node-addon-api/async_worker.test.js
@@ -5,63 +5,64 @@ const common = require('./common')
 
 // we only check async hooks on 8.x an higher were
 // they are closer to working properly
-// const nodeVersion = process.versions.node.split('.')[0]
-// let asyncHooks
+const nodeVersion = process.versions.node.split('.')[0]
+let asyncHooks
 function checkAsyncHooks () {
-  // if (nodeVersion >= 8) {
-  //   if (asyncHooks === undefined) {
-  //     asyncHooks = require('async_hooks')
-  //   }
-  //   return true
-  // }
+  if (nodeVersion >= 8) {
+    if (asyncHooks === undefined) {
+      asyncHooks = require('async_hooks')
+    }
+    return true
+  }
   return false
 }
 
 module.exports = common.runTest(test)
 
-// function installAsyncHooksForTest () {
-//   return new Promise((resolve, reject) => {
-//     let id
-//     const events = []
-//     /**
-//      * TODO(legendecas): investigate why resolving & disabling hooks in
-//      * destroy callback causing crash with case 'callbackscope.js'.
-//      */
-//     let destroyed = false
-//     const interval = setInterval(() => {
-//       if (destroyed) {
-//         hook.disable()
-//         clearInterval(interval)
-//         resolve(events)
-//       }
-//     }, 10)
+function installAsyncHooksForTest () {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  return new Promise((resolve, reject) => {
+    let id
+    const events = []
+    /**
+     * TODO(legendecas): investigate why resolving & disabling hooks in
+     * destroy callback causing crash with case 'callbackscope.js'.
+     */
+    let destroyed = false
+    const interval = setInterval(() => {
+      if (destroyed) {
+        hook.disable()
+        clearInterval(interval)
+        resolve(events)
+      }
+    }, 10)
 
-//     const hook = asyncHooks.createHook({
-//       init (asyncId, type, triggerAsyncId, resource) {
-//         if (id === undefined && type === 'TestResource') {
-//           id = asyncId
-//           events.push({ eventName: 'init', type, triggerAsyncId, resource })
-//         }
-//       },
-//       before (asyncId) {
-//         if (asyncId === id) {
-//           events.push({ eventName: 'before' })
-//         }
-//       },
-//       after (asyncId) {
-//         if (asyncId === id) {
-//           events.push({ eventName: 'after' })
-//         }
-//       },
-//       destroy (asyncId) {
-//         if (asyncId === id) {
-//           events.push({ eventName: 'destroy' })
-//           destroyed = true
-//         }
-//       }
-//     }).enable()
-//   })
-// }
+    const hook = asyncHooks.createHook({
+      init (asyncId, type, triggerAsyncId, resource) {
+        if (id === undefined && type === 'TestResource') {
+          id = asyncId
+          events.push({ eventName: 'init', type, triggerAsyncId, resource })
+        }
+      },
+      before (asyncId) {
+        if (asyncId === id) {
+          events.push({ eventName: 'before' })
+        }
+      },
+      after (asyncId) {
+        if (asyncId === id) {
+          events.push({ eventName: 'after' })
+        }
+      },
+      destroy (asyncId) {
+        if (asyncId === id) {
+          events.push({ eventName: 'destroy' })
+          destroyed = true
+        }
+      }
+    }).enable()
+  })
+}
 
 async function test (binding) {
   const libUvThreadCount = Number(process.env.UV_THREADPOOL_SIZE || 4)
@@ -111,8 +112,8 @@ async function test (binding) {
   }
 
   {
-    // const hooks = installAsyncHooksForTest()
-    // const triggerAsyncId = asyncHooks.executionAsyncId()
+    const hooks = installAsyncHooksForTest()
+    const triggerAsyncId = asyncHooks.executionAsyncId()
     await new Promise((resolve) => {
       binding.asyncworker.doWork(true, { foo: 'foo' }, function (e) {
         assert.strictEqual(typeof e, 'undefined')
@@ -122,24 +123,24 @@ async function test (binding) {
       }, 'test data')
     })
 
-    // await hooks.then(actual => {
-    //   assert.deepStrictEqual(actual, [
-    //     {
-    //       eventName: 'init',
-    //       type: 'TestResource',
-    //       triggerAsyncId,
-    //       resource: { foo: 'foo' }
-    //     },
-    //     { eventName: 'before' },
-    //     { eventName: 'after' },
-    //     { eventName: 'destroy' }
-    //   ])
-    // }).catch(common.mustNotCall())
+    await hooks.then(actual => {
+      assert.deepStrictEqual(actual, [
+        {
+          eventName: 'init',
+          type: 'TestResource',
+          triggerAsyncId,
+          resource: { foo: 'foo' }
+        },
+        { eventName: 'before' },
+        { eventName: 'after' },
+        { eventName: 'destroy' }
+      ])
+    }).catch(common.mustNotCall())
   }
 
   {
-    // const hooks = installAsyncHooksForTest()
-    // const triggerAsyncId = asyncHooks.executionAsyncId()
+    const hooks = installAsyncHooksForTest()
+    const triggerAsyncId = asyncHooks.executionAsyncId()
     await new Promise((resolve) => {
       binding.asyncworker.doWorkWithResult(true, { foo: 'foo' },
         function (succeed, succeedString) {
@@ -152,24 +153,24 @@ async function test (binding) {
         }, 'test data')
     })
 
-    // await hooks.then(actual => {
-    //   assert.deepStrictEqual(actual, [
-    //     {
-    //       eventName: 'init',
-    //       type: 'TestResource',
-    //       triggerAsyncId,
-    //       resource: { foo: 'foo' }
-    //     },
-    //     { eventName: 'before' },
-    //     { eventName: 'after' },
-    //     { eventName: 'destroy' }
-    //   ])
-    // }).catch(common.mustNotCall())
+    await hooks.then(actual => {
+      assert.deepStrictEqual(actual, [
+        {
+          eventName: 'init',
+          type: 'TestResource',
+          triggerAsyncId,
+          resource: { foo: 'foo' }
+        },
+        { eventName: 'before' },
+        { eventName: 'after' },
+        { eventName: 'destroy' }
+      ])
+    }).catch(common.mustNotCall())
   }
 
   {
-    // const hooks = installAsyncHooksForTest()
-    // const triggerAsyncId = asyncHooks.executionAsyncId()
+    const hooks = installAsyncHooksForTest()
+    const triggerAsyncId = asyncHooks.executionAsyncId()
     await new Promise((resolve) => {
       binding.asyncworker.doWork(false, { foo: 'foo' }, function (e) {
         assert.ok(e instanceof Error)
@@ -180,18 +181,18 @@ async function test (binding) {
       }, 'test data')
     })
 
-    // await hooks.then(actual => {
-    //   assert.deepStrictEqual(actual, [
-    //     {
-    //       eventName: 'init',
-    //       type: 'TestResource',
-    //       triggerAsyncId,
-    //       resource: { foo: 'foo' }
-    //     },
-    //     { eventName: 'before' },
-    //     { eventName: 'after' },
-    //     { eventName: 'destroy' }
-    //   ])
-    // }).catch(common.mustNotCall())
+    await hooks.then(actual => {
+      assert.deepStrictEqual(actual, [
+        {
+          eventName: 'init',
+          type: 'TestResource',
+          triggerAsyncId,
+          resource: { foo: 'foo' }
+        },
+        { eventName: 'before' },
+        { eventName: 'after' },
+        { eventName: 'destroy' }
+      ])
+    }).catch(common.mustNotCall())
   }
 }

--- a/packages/test/node-addon-api/common/index.js
+++ b/packages/test/node-addon-api/common/index.js
@@ -91,7 +91,7 @@ async function runTest (test, buildType, buildPathRoot = process.env.BUILD_PATH 
   ]/* .map(it => require.resolve(it)) */
 
   for (const item of bindings) {
-    const binding = await load(item)
+    const binding = await load(item, { nodeBinding: require('@tybys/emnapi-node-binding') })
     console.log('>>>>>>>>' + item)
     await Promise.resolve(test(binding))
       .finally(exports.mustCall())

--- a/packages/test/script/test.js
+++ b/packages/test/script/test.js
@@ -35,7 +35,17 @@ files.forEach((f) => {
 })
 
 function test (f) {
-  const r = spawnSync('node', ['--expose-gc', ...(process.env.MEMORY64 ? ['--experimental-wasm-memory64'] : []), './script/test-entry.js', f], { cwd, env: process.env, stdio: 'inherit' })
+  const additionalFlags = []
+  if (f.includes('async_context')) {
+    additionalFlags.push('--gc-interval=100', '--gc-global')
+  }
+  const r = spawnSync('node', [
+    '--expose-gc',
+    ...additionalFlags,
+    ...(process.env.MEMORY64 ? ['--experimental-wasm-memory64'] : []),
+    './script/test-entry.js',
+    f
+  ], { cwd, env: process.env, stdio: 'inherit' })
   if (r.status !== 0) {
     process.exit(r.status)
   }

--- a/packages/test/tsfn/tsfn.test.js
+++ b/packages/test/tsfn/tsfn.test.js
@@ -6,7 +6,7 @@ const assert = require('assert')
 // const { fork } = require('child_process')
 
 async function main () {
-  const loadPromise = load('tsfn')
+  const loadPromise = load('tsfn', { nodeBinding: require('@tybys/emnapi-node-binding') })
   const binding = await loadPromise
 
   const expectedArray = (function (arrayLength) {


### PR DESCRIPTION
Add custom asynchronous operations API support and `async_resource` parameter of `napi_create_async_work` and `napi_create_threadsafe_function` on Node.js

- napi_async_init
- napi_async_destroy
- napi_make_callback

return `napi_generic_failure` on browser or `nodeBinding` is not provided when initializing.

```js
Module.emnapiInit({
  context,
  nodeBinding: require('@tybys/emnapi-node-binding')
})
```

`napi_{open,close}_callback_scope` can not be implemented because Node.js disallow mismatched callback scope after returning back to JavaScript.
