### PR TITLE
prebuild wasm32-wasi-threads libraries

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,8 @@ on:
     - '!packages/bench/**'
     - '!script/**'
     - '!example/**'
+    branches:
+    - main
   pull_request:
   workflow_dispatch:
 
@@ -50,23 +52,11 @@ jobs:
         target: ${{ matrix.target }}
 
     - name: Install wasi-sdk
-      if: ${{ matrix.target == 'wasm32-unknown-unknown' || matrix.target == 'wasm32-wasi' }}
+      if: ${{ matrix.target == 'wasm32-unknown-unknown' || matrix.target == 'wasm32-wasi' || matrix.target == 'wasm32-wasi-threads' }}
       env:
-        WASI_VERSION: '19'
-        WASI_VERSION_FULL: '19.0'
-        WASI_SDK_PATH: './wasi-sdk-19.0'
-      shell: bash
-      run: |
-        wget -q https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_VERSION}/wasi-sdk-${WASI_VERSION_FULL}-linux.tar.gz
-        mkdir -p $WASI_SDK_PATH
-        tar zxvf wasi-sdk-${WASI_VERSION_FULL}-linux.tar.gz -C $WASI_SDK_PATH --strip 1
-
-    - name: Install wasi-sdk with threads
-      if: ${{ matrix.target == 'wasm32-wasi-threads' }}
-      env:
-        WASI_VERSION: '20+threads'
-        WASI_VERSION_FULL: '20.0.threads'
-        WASI_SDK_PATH: './wasi-sdk-20.0.threads'
+        WASI_VERSION: '20'
+        WASI_VERSION_FULL: '20.0'
+        WASI_SDK_PATH: './wasi-sdk-20.0'
       shell: bash
       run: |
         wget -q https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_VERSION}/wasi-sdk-${WASI_VERSION_FULL}-linux.tar.gz
@@ -96,13 +86,10 @@ jobs:
     - name: Test wasm32-wasi-threads
       if: ${{ matrix.target == 'wasm32-wasi-threads' }}
       env:
-        WASI_VERSION: '20+threads'
-        WASI_VERSION_FULL: '20.0.threads'
-        WASI_SDK_PATH: './wasi-sdk-20.0.threads'
+        WASI_VERSION: '20'
+        WASI_VERSION_FULL: '20.0'
+        WASI_SDK_PATH: './wasi-sdk-20.0'
       run: |
-        echo "set(CMAKE_C_COMPILER_WORKS 1)" >> $WASI_SDK_PATH/share/cmake/wasi-sdk-pthread.cmake
-        echo "set(CMAKE_CXX_COMPILER_WORKS 1)" >> $WASI_SDK_PATH/share/cmake/wasi-sdk-pthread.cmake
-        cp -rpf $WASI_SDK_PATH/share/wasi-sysroot/lib/wasm32-wasi/libc++* $WASI_SDK_PATH/share/wasi-sysroot/lib/wasm32-wasi-threads/
         npm run rebuild:wt -w packages/test
         npm run test:wt -w packages/test
 
@@ -123,9 +110,9 @@ jobs:
     - name: Test wasm32-wasi
       if: ${{ matrix.target == 'wasm32-wasi' }}
       env:
-        WASI_VERSION: '19'
-        WASI_VERSION_FULL: '19.0'
-        WASI_SDK_PATH: './wasi-sdk-19.0'
+        WASI_VERSION: '20'
+        WASI_VERSION_FULL: '20.0'
+        WASI_SDK_PATH: './wasi-sdk-20.0'
       run: |
         npm run rebuild:w -w packages/test
         cd ./packages/test/rust && cargo build --release --target=wasm32-wasi && cd ../../..
@@ -134,9 +121,9 @@ jobs:
     - name: Test wasm32-unknown-unknown
       if: ${{ matrix.target == 'wasm32-unknown-unknown' }}
       env:
-        WASI_VERSION: '19'
-        WASI_VERSION_FULL: '19.0'
-        WASI_SDK_PATH: './wasi-sdk-19.0'
+        WASI_VERSION: '20'
+        WASI_VERSION_FULL: '20.0'
+        WASI_SDK_PATH: './wasi-sdk-20.0'
       run: |
         npm run rebuild:wasm32 -w packages/test
         cd ./packages/test/rust && cargo build --release --target=wasm32-unknown-unknown && cd ../../..
@@ -148,9 +135,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     env:
-      WASI_VERSION: '19'
-      WASI_VERSION_FULL: '19.0'
-      WASI_SDK_PATH: './wasi-sdk-19.0'
+      WASI_VERSION: '20'
+      WASI_VERSION_FULL: '20.0'
+      WASI_SDK_PATH: './wasi-sdk-20.0'
 
     steps:
     - uses: actions/checkout@v3

--- a/packages/emnapi/README.md
+++ b/packages/emnapi/README.md
@@ -728,7 +728,7 @@ instantiateNapiModule(wasmBuffer, {
       ...importObject.emnapi
     }
   }
-}).then(({ instance, napiModule }) => {
+}).then(({ napiModule }) => {
   const binding = napiModule.exports
   // output: 5
   console.log(binding.fibonacci(5))
@@ -778,16 +778,18 @@ Cross-Origin-Embedder-Policy: require-corp
 Cross-Origin-Opener-Policy: same-origin
 ```
 
+If you would like to avoid `SharedArrayBuffer` and cross-origin isolation, please use B & E (link against `libemnapi-basic.a`), see the following table for more details.
+
 #### About Prebuilt Libraries
 
 Prebuilt libraries can be found in the `lib` directory in `emnapi` npm package.
 
 | Library              | Description                                                                                                                                                                                                                                                   | `wasm32-emscripten` | `wasm32` | `wasm32-wasi` | `wasm32-wasi-threads`                   |
 |----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------|----------|---------------|-----------------------------------------|
-| libemnapi.a          | no atomics feature.<br/><br/> no libuv port.<br/><br/> `napi_*_async_work` and `napi_*_threadsafe_function` always return `napi_generic_failure`.                                                                                                                         | ✅                   | ✅        | ✅             | waiting wasi-sdk release thread support |
-| libemnapi-mt.a       | atomics feature enabled.<br/><br/> `napi_*_async_work` and `napi_*_threadsafe_function` are based on pthread and libuv port.                                                                                                                                        | ✅                   | ❌        | ❌             | waiting wasi-sdk release thread support |
-| libemnapi-basic.a    | no atomics feature.<br/><br/> no libuv port.<br/><br/> `napi_*_async_work` and `napi_*_threadsafe_function` are imported from JavaScript land.                                                                                                                            | ✅                   | ✅        | ✅             | waiting wasi-sdk release thread support |
-| libemnapi-basic-mt.a | atomics feature enabled.<br/><br/> no libuv port.<br/><br/> `napi_*_async_work` and `napi_*_threadsafe_function` are imported from JavaScript land.<br/><br/> include `emnapi_async_worker_create` and `emnapi_async_worker_init` for WebWorker based async work implementation. | ❌                   | ✅        | ✅             | waiting wasi-sdk release thread support |
+| libemnapi.a          | no atomics feature.<br/><br/> no libuv port.<br/><br/> `napi_*_async_work` and `napi_*_threadsafe_function` always return `napi_generic_failure`.                                                                                                                         | ✅                   | ✅        | ✅             | ✅ |
+| libemnapi-mt.a       | atomics feature enabled.<br/><br/> `napi_*_async_work` and `napi_*_threadsafe_function` are based on pthread and libuv port.                                                                                                                                        | ✅                   | ❌        | ❌             | ✅ |
+| libemnapi-basic.a    | no atomics feature.<br/><br/> no libuv port.<br/><br/> `napi_*_async_work` and `napi_*_threadsafe_function` are imported from JavaScript land.                                                                                                                            | ✅                   | ✅        | ✅             | ✅ |
+| libemnapi-basic-mt.a | atomics feature enabled.<br/><br/> no libuv port.<br/><br/> `napi_*_async_work` and `napi_*_threadsafe_function` are imported from JavaScript land.<br/><br/> include `emnapi_async_worker_create` and `emnapi_async_worker_init` for WebWorker based async work implementation. | ❌                   | ✅        | ✅             | ✅ |
 | libdlmalloc.a        | no atomics feature, no thread safe garanteed.                                                                                                                                                                                                                 | ❌                   | ✅        | ❌             | ❌                                       |
 | libdlmalloc-mt.a     | atomics feature enabled, thread safe.                                                                                                                                                                                                                         | ❌                   | ✅        | ❌             | ❌                                       |
 | libemmalloc.a        | no atomics feature, no thread safe garanteed.                                                                                                                                                                                                                 | ❌                   | ✅        | ❌             | ❌                                       |

--- a/packages/test/CMakeLists.txt
+++ b/packages/test/CMakeLists.txt
@@ -310,8 +310,7 @@ add_test("version" "./version/binding.c" OFF OFF "")
 add_test("make_callback" "./make_callback/binding.c" OFF OFF "")
 add_test("async_context" "./async_context/binding.c" OFF OFF "")
 
-# TODO(wasm32-wasi-threads): OR IS_WASI_THREADS
-if(IS_EMSCRIPTEN)
+if(IS_EMSCRIPTEN OR IS_WASI_THREADS)
   file(GLOB_RECURSE naa_binding_SRC
     "./node-addon-api/*.cc")
 

--- a/packages/test/script/test.js
+++ b/packages/test/script/test.js
@@ -39,14 +39,6 @@ if (process.env.EMNAPI_TEST_NATIVE) {
   ])]
 }
 
-// # TODO(wasm32-wasi-threads): Remove this
-if (process.env.EMNAPI_TEST_WASI_THREADS) {
-  ignore = [...new Set([
-    ...ignore,
-    'node-addon-api/**/*'
-  ])]
-}
-
 let files = glob.sync(subdir
   ? subdir.endsWith('.js')
     ? subdir

--- a/script/release.js
+++ b/script/release.js
@@ -147,6 +147,12 @@ async function main () {
   fs.copySync(path.join(sysroot, 'lib/emnapi', 'wasm32-wasi.txt'), path.join(__dirname, '../packages/emnapi/lib/wasm32-wasi.txt'))
   fs.copySync(path.join(sysroot, 'lib/emnapi', 'wasm32-emscripten.txt'), path.join(__dirname, '../packages/emnapi/lib/wasm32-emscripten.txt'))
 
+  if (WASI_THREADS_CMAKE_TOOLCHAIN_FILE) {
+    const { stderr: wasiSdkClangVersion } = spawnSync(path.join(WASI_SDK_PATH, 'bin/clang' + (process.platform === 'win32' ? '.exe' : '')), ['-v', '--target=wasm32-wasi-threads'])
+    fs.writeFileSync(path.join(sysroot, 'lib/emnapi', 'wasm32-wasi-threads.txt'), wasiSdkClangVersion)
+    fs.copySync(path.join(sysroot, 'lib/emnapi', 'wasm32-wasi-threads.txt'), path.join(__dirname, '../packages/emnapi/lib/wasm32-wasi-threads.txt'))
+  }
+
   fs.copyFileSync(path.join(__dirname, '../packages/runtime/dist/emnapi.js'), path.join(sysroot, 'lib/emnapi', 'emnapi.js'))
   fs.copyFileSync(path.join(__dirname, '../packages/runtime/dist/emnapi.min.js'), path.join(sysroot, 'lib/emnapi', 'emnapi.min.js'))
   fs.copyFileSync(path.join(__dirname, '../packages/runtime/dist/emnapi.d.ts'), path.join(sysroot, 'lib/emnapi', 'emnapi.d.ts'))


### PR DESCRIPTION
[wasi-sdk-20](https://github.com/WebAssembly/wasi-sdk/releases/tag/wasi-sdk-20) is available.