### PR TITLE
Expose threadpool cleanup

### DIFF
--- a/packages/emnapi/include/uv.h
+++ b/packages/emnapi/include/uv.h
@@ -40,6 +40,7 @@ struct uv_req_s {
   UV_REQ_FIELDS
 };
 
+UV_EXTERN void uv_library_shutdown(void);
 UV_EXTERN uv_loop_t* uv_default_loop(void);
 UV_EXTERN int uv_loop_init(uv_loop_t* loop);
 UV_EXTERN int uv_loop_close(uv_loop_t* loop);

--- a/packages/emnapi/include/uv.h
+++ b/packages/emnapi/include/uv.h
@@ -53,6 +53,7 @@ UV_EXTERN void uv_sem_wait(uv_sem_t* sem);
 UV_EXTERN int uv_cond_init(uv_cond_t* cond);
 UV_EXTERN void uv_cond_signal(uv_cond_t* cond);
 UV_EXTERN void uv_cond_wait(uv_cond_t* cond, uv_mutex_t* mutex);
+UV_EXTERN void uv_cond_destroy(uv_cond_t* cond);
 
 UV_EXTERN void uv_once(uv_once_t* guard, void (*callback)(void));
 
@@ -75,6 +76,7 @@ UV_EXTERN int uv_mutex_init(uv_mutex_t* mutex);
 UV_EXTERN void uv_mutex_destroy(uv_mutex_t* handle);
 UV_EXTERN void uv_mutex_lock(uv_mutex_t* handle);
 UV_EXTERN void uv_mutex_unlock(uv_mutex_t* handle);
+UV_EXTERN void uv_mutex_destroy(uv_mutex_t* cond);
 
 typedef void (*uv_thread_cb)(void* arg);
 

--- a/packages/emnapi/src/uv/threadpool.c
+++ b/packages/emnapi/src/uv/threadpool.c
@@ -180,34 +180,34 @@ static void post(QUEUE* q, enum uv__work_kind kind) {
 }
 
 
-// #ifdef __MVS__
-// /* TODO(itodorov) - zos: revisit when Woz compiler is available. */
-// __attribute__((destructor))
-// #endif
-// void uv__threadpool_cleanup(void) {
-//   unsigned int i;
+#ifdef __MVS__
+/* TODO(itodorov) - zos: revisit when Woz compiler is available. */
+__attribute__((destructor))
+#endif
+void uv__threadpool_cleanup(void) {
+  unsigned int i;
 
-//   if (nthreads == 0)
-//     return;
+  if (nthreads == 0)
+    return;
 
-// #ifndef __MVS__
-//   /* TODO(gabylb) - zos: revisit when Woz compiler is available. */
-//   post(&exit_message, UV__WORK_CPU);
-// #endif
+#ifndef __MVS__
+  /* TODO(gabylb) - zos: revisit when Woz compiler is available. */
+  post(&exit_message, UV__WORK_CPU);
+#endif
 
-//   for (i = 0; i < nthreads; i++)
-//     if (uv_thread_join(threads + i))
-//       abort();
+  for (i = 0; i < nthreads; i++)
+    if (uv_thread_join(threads + i))
+      abort();
 
-//   if (threads != default_threads)
-//     free(threads);
+  if (threads != default_threads)
+    free(threads);
 
-//   uv_mutex_destroy(&mutex);
-//   uv_cond_destroy(&cond);
+  uv_mutex_destroy(&mutex);
+  uv_cond_destroy(&cond);
 
-//   threads = NULL;
-//   nthreads = 0;
-// }
+  threads = NULL;
+  nthreads = 0;
+}
 
 EMNAPI_EXTERN int _emnapi_async_work_pool_size();
 

--- a/packages/emnapi/src/uv/unix/thread.c
+++ b/packages/emnapi/src/uv/unix/thread.c
@@ -98,6 +98,11 @@ void uv_cond_wait(uv_cond_t* cond, uv_mutex_t* mutex) {
     abort();
 }
 
+void uv_cond_destroy(uv_cond_t* cond) {
+  if (pthread_cond_destroy(cond))
+    abort();
+}
+
 int uv_thread_create_ex(uv_thread_t* tid,
                         void* params,
                         void (*entry)(void *arg),

--- a/packages/emnapi/src/uv/uv-common.c
+++ b/packages/emnapi/src/uv/uv-common.c
@@ -48,4 +48,23 @@ int uv_loop_close(uv_loop_t* loop) {
   return 0;
 }
 
+#if defined(__GNUC__) && !defined(_WIN32)
+__attribute__((destructor))
+#endif
+void uv_library_shutdown(void) {
+  static int was_shutdown;
+
+  if (uv__exchange_int_relaxed(&was_shutdown, 1))
+    return;
+
+//   uv__process_title_cleanup();
+//   uv__signal_cleanup();
+// #ifdef __MVS__
+//   /* TODO(itodorov) - zos: revisit when Woz compiler is available. */
+//   uv__os390_cleanup();
+// #else
+  uv__threadpool_cleanup();
+// #endif
+}
+
 #endif

--- a/packages/emnapi/src/uv/uv-common.h
+++ b/packages/emnapi/src/uv/uv-common.h
@@ -18,6 +18,9 @@
 #include <assert.h>
 #include "uv.h"
 #include "queue.h"
+#ifndef _MSC_VER
+# include <stdatomic.h>
+#endif
 
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
 // #define offsetof(s, m) __builtin_offsetof(s, m)
@@ -53,12 +56,16 @@
   }                                                                           \
   while (0)
 
+#define uv__exchange_int_relaxed(p, v)                                        \
+  atomic_exchange_explicit((_Atomic int*)(p), v, memory_order_relaxed)
+
 enum uv__work_kind {
   UV__WORK_CPU,
   UV__WORK_FAST_IO,
   UV__WORK_SLOW_IO
 };
 
+void uv__threadpool_cleanup(void);
 void uv__work_done(uv_async_t* handle);
 void uv__loop_close(uv_loop_t* loop);
 void uv__async_close(uv_async_t* handle);


### PR DESCRIPTION
Exposing threadpool cleanup from libuv + adding missing API.

While proper cleanup is not critical in Node.js, where exiting process automatically kills all associated threads, it's important for environments like Stackblitz where otherwise spawned Worker will be stuck waiting on a condvar (on an atomic) forever in background even after the Node.js command has finished, leading to Worker leaks.