### PR TITLE
represent `napi_callback_info` with non-zero number

### DIFF
--- a/packages/emnapi/src/function.ts
+++ b/packages/emnapi/src/function.ts
@@ -20,11 +20,11 @@ function napi_create_function (env: napi_env, utf8name: Pointer<const_char>, len
   })
 }
 
-function napi_get_cb_info (env: napi_env, _cbinfo: napi_callback_info, argc: Pointer<size_t>, argv: Pointer<napi_value>, this_arg: Pointer<napi_value>, data: void_pp): napi_status {
+function napi_get_cb_info (env: napi_env, cbinfo: napi_callback_info, argc: Pointer<size_t>, argv: Pointer<napi_value>, this_arg: Pointer<napi_value>, data: void_pp): napi_status {
   $CHECK_ENV!(env)
   const envObject = emnapiCtx.envStore.get(env)!
 
-  const cbinfoValue = emnapiCtx.cbinfoStack.current!
+  const cbinfoValue = emnapiCtx.cbinfoStack.get(cbinfo)!
 
   $from64('argc')
   $from64('argv')
@@ -160,7 +160,7 @@ function napi_new_instance (
 
 function napi_get_new_target (
   env: napi_env,
-  _cbinfo: napi_callback_info,
+  cbinfo: napi_callback_info,
   result: Pointer<napi_value>
 ): napi_status {
   $CHECK_ENV!(env)
@@ -170,7 +170,7 @@ function napi_get_new_target (
 
   $from64('result')
 
-  const cbinfoValue = emnapiCtx.cbinfoStack.current!
+  const cbinfoValue = emnapiCtx.cbinfoStack.get(cbinfo)!
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const value = cbinfoValue.getNewTarget(envObject)
   $makeSetValue('result', 0, 'value', '*')

--- a/packages/emnapi/src/internal.ts
+++ b/packages/emnapi/src/internal.ts
@@ -11,11 +11,11 @@ function emnapiCreateFunction<F extends (...args: any[]) => any> (envObject: Env
 
   const makeFunction = () => function (this: any): any {
     'use strict'
-    emnapiCtx.cbinfoStack.push(this, data, arguments, f)
+    const cbinfo = emnapiCtx.cbinfoStack.push(this, data, arguments, f)
     const scope = emnapiCtx.openScope(envObject)
     try {
       return envObject.callIntoModule((envObject) => {
-        const napiValue = $makeDynCall('ppp', 'cb')(envObject.id, 0)
+        const napiValue = $makeDynCall('ppp', 'cb')(envObject.id, cbinfo)
         return (!napiValue) ? undefined : emnapiCtx.handleStore.get(napiValue)!.value
       })
     } finally {

--- a/packages/test/CMakeLists.txt
+++ b/packages/test/CMakeLists.txt
@@ -264,6 +264,7 @@ if((NOT IS_WASM) OR IS_EMSCRIPTEN OR IS_WASI_THREADS)
 endif()
 
 add_test("arg" "./arg/binding.c" ON OFF "")
+add_test("cbinfo" "./cbinfo/binding.c" ON OFF "")
 add_test("callback" "./callback/binding.c" ON OFF "")
 add_test("objfac" "./objfac/binding.c" ON OFF "")
 add_test("fnfac" "./fnfac/binding.c" ON OFF "")

--- a/packages/test/cbinfo/binding.c
+++ b/packages/test/cbinfo/binding.c
@@ -1,0 +1,69 @@
+#include <js_native_api.h>
+#include "../common.h"
+
+static napi_value Test1(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  NAPI_ASSERT(env, argc == 1,
+      "Test1: Wrong number of arguments. Expects a single argument.");
+
+  napi_valuetype valuetype0;
+  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
+  NAPI_ASSERT(env, valuetype0 == napi_function,
+      "Test1: Wrong type of arguments. Expects a function as first argument.");
+
+  napi_value argv[1];
+  NAPI_CALL(env, napi_create_bigint_int64(env, (int64_t) info, argv));
+
+  napi_value global;
+  NAPI_CALL(env, napi_get_global(env, &global));
+
+  napi_value cb = args[0];
+  NAPI_CALL(env, napi_call_function(env, global, cb, 1, argv, NULL));
+
+  return NULL;
+}
+
+static napi_value Test2(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value args[1];
+  NAPI_CALL(env, napi_get_cb_info(env, info, &argc, args, NULL, NULL));
+
+  NAPI_ASSERT(env, argc == 1,
+      "Test2: Wrong number of arguments. Expects a single argument.");
+
+  napi_valuetype valuetype0;
+  NAPI_CALL(env, napi_typeof(env, args[0], &valuetype0));
+  NAPI_ASSERT(env, valuetype0 == napi_bigint,
+      "Test2: Wrong type of arguments. Expects a bigint as first argument.");
+  
+  int64_t prev_info;
+  bool lossless;
+  NAPI_CALL(env, napi_get_value_bigint_int64(env, args[0], &prev_info, &lossless));
+
+  size_t prev_argc = 1;
+  napi_value prev_args[1];
+  NAPI_CALL(env, napi_get_cb_info(env, (napi_callback_info) prev_info, &prev_argc, prev_args, NULL, NULL));
+
+  NAPI_ASSERT(env, prev_argc == 1,
+      "Test2: Wrong number of arguments. Expects a single argument.");
+
+  napi_valuetype t;
+  NAPI_CALL(env, napi_typeof(env, prev_args[0], &t));
+  NAPI_ASSERT(env, t == napi_function,
+      "Test2: Wrong type of arguments. Expects a function as first argument.");
+  return NULL;
+}
+
+EXTERN_C_START
+napi_value Init(napi_env env, napi_value exports) {
+  napi_property_descriptor desc[2] = {
+    DECLARE_NAPI_PROPERTY("test1", Test1),
+    DECLARE_NAPI_PROPERTY("test2", Test2),
+  };
+  NAPI_CALL(env, napi_define_properties(env, exports, 2, desc));
+  return exports;
+}
+EXTERN_C_END

--- a/packages/test/cbinfo/cbinfo.test.js
+++ b/packages/test/cbinfo/cbinfo.test.js
@@ -1,0 +1,6 @@
+'use strict'
+const { load } = require('../util')
+
+module.exports = load('cbinfo').then(addon => {
+  addon.test1(addon.test2)
+})


### PR DESCRIPTION
Previously `napi_callback_info` was always 0, calling `napi_get_cb_info` could only get the JS callback information of the function at the top of the call stack.