### PR TITLE
sync latest headers

### DIFF
--- a/packages/emnapi/CMakeLists.txt
+++ b/packages/emnapi/CMakeLists.txt
@@ -40,11 +40,16 @@ set(EMNAPI_THREADS_SRC
 set(EMNAPI_SRC ${ENAPI_BASIC_SRC} ${EMNAPI_THREADS_SRC})
 
 set(EMNAPI_INCLUDE "${CMAKE_CURRENT_SOURCE_DIR}/include")
+set(EMNAPI_DEFINES "BUILDING_NODE_EXTENSION")
 
 set(EMNAPI_JS_LIB "${CMAKE_CURRENT_SOURCE_DIR}/dist/library_napi.js")
 
 if(IS_EMSCRIPTEN)
   set(EMNAPI_MT_CFLAGS "-pthread" "-sWASM_WORKERS=1")
+
+  # https://github.com/emscripten-core/emscripten/issues/20035
+  # https://github.com/emscripten-core/emscripten/pull/20130
+  list(APPEND EMNAPI_DEFINES "NAPI_EXTERN=__attribute__((__import_module__(\"env\")))")
 else()
   set(EMNAPI_MT_CFLAGS "-pthread")
 endif()
@@ -115,12 +120,14 @@ endif()
 
 add_library(${EMNAPI_TARGET_NAME} STATIC ${EMNAPI_SRC} ${UV_SRC})
 target_include_directories(${EMNAPI_TARGET_NAME} PUBLIC ${EMNAPI_INCLUDE})
+target_compile_definitions(${EMNAPI_TARGET_NAME} PUBLIC ${EMNAPI_DEFINES})
 if(IS_EMSCRIPTEN)
   target_link_options(${EMNAPI_TARGET_NAME} INTERFACE "--js-library=${EMNAPI_JS_LIB}")
 endif()
 
 add_library(${EMNAPI_BASIC_TARGET_NAME} STATIC ${ENAPI_BASIC_SRC})
 target_include_directories(${EMNAPI_BASIC_TARGET_NAME} PUBLIC ${EMNAPI_INCLUDE})
+target_compile_definitions(${EMNAPI_BASIC_TARGET_NAME} PUBLIC ${EMNAPI_DEFINES})
 if(IS_EMSCRIPTEN)
   target_link_options(${EMNAPI_BASIC_TARGET_NAME} INTERFACE "--js-library=${EMNAPI_JS_LIB}")
 endif()
@@ -139,6 +146,7 @@ if(EMNAPI_BUILD_BASIC_MT)
   )
   target_compile_options(${EMNAPI_BASIC_MT_TARGET_NAME} PUBLIC "-matomics" "-mbulk-memory")
   target_include_directories(${EMNAPI_BASIC_MT_TARGET_NAME} PUBLIC ${EMNAPI_INCLUDE})
+  target_compile_definitions(${EMNAPI_BASIC_MT_TARGET_NAME} PUBLIC ${EMNAPI_DEFINES})
 endif()
 
 if(IS_EMSCRIPTEN OR (CMAKE_C_COMPILER_TARGET STREQUAL "wasm32-wasi-threads"))
@@ -151,6 +159,7 @@ if(EMNAPI_BUILD_MT)
   add_library(${EMNAPI_MT_TARGET_NAME} STATIC ${EMNAPI_SRC} ${UV_SRC})
   target_compile_options(${EMNAPI_MT_TARGET_NAME} PRIVATE ${EMNAPI_MT_CFLAGS})
   target_include_directories(${EMNAPI_MT_TARGET_NAME} PUBLIC ${EMNAPI_INCLUDE})
+  target_compile_definitions(${EMNAPI_MT_TARGET_NAME} PUBLIC ${EMNAPI_DEFINES})
   if(IS_EMSCRIPTEN)
     target_link_options(${EMNAPI_MT_TARGET_NAME} INTERFACE "--js-library=${EMNAPI_JS_LIB}")
   endif()

--- a/packages/emnapi/README.md
+++ b/packages/emnapi/README.md
@@ -165,6 +165,8 @@ module.exports = (function (exports) {
 
 ```bash
 emcc -O3 \
+     -DBUILDING_NODE_EXTENSION \
+     "-DNAPI_EXTERN=__attribute__((__import_module__(\"env\")))" \
      -I./node_modules/emnapi/include \
      -L./node_modules/emnapi/lib/wasm32-emscripten \
      --js-library=./node_modules/emnapi/dist/library_napi.js \
@@ -181,6 +183,7 @@ emcc -O3 \
 
 ```bash
 clang -O3 \
+      -DBUILDING_NODE_EXTENSION \
       -I./node_modules/emnapi/include \
       -L./node_modules/emnapi/lib/wasm32-wasi \
       --target=wasm32-wasi \
@@ -208,6 +211,7 @@ Choose `libdlmalloc.a` or `libemmalloc.a` for `malloc` and `free`.
 
 ```bash
 clang -O3 \
+      -DBUILDING_NODE_EXTENSION \
       -I./node_modules/emnapi/include \
       -L./node_modules/emnapi/lib/wasm32 \
       --target=wasm32 \
@@ -448,6 +452,8 @@ Compile `hello.cpp` using `em++`. C++ exception is disabled by Emscripten defaul
 
 ```bash
 em++ -O3 \
+     -DBUILDING_NODE_EXTENSION \
+     "-DNAPI_EXTERN=__attribute__((__import_module__(\"env\")))" \
      -DNAPI_DISABLE_CPP_EXCEPTIONS \
      -DNODE_ADDON_API_ENABLE_MAYBE \
      -I./node_modules/emnapi/include \
@@ -467,6 +473,7 @@ em++ -O3 \
 
 ```bash
 clang++ -O3 \
+        -DBUILDING_NODE_EXTENSION \
         -DNAPI_DISABLE_CPP_EXCEPTIONS \
         -DNODE_ADDON_API_ENABLE_MAYBE \
         -I./node_modules/emnapi/include \
@@ -500,6 +507,7 @@ You can still use `wasm32-unknown-unknown` target if you use Node-API C API only
 
 ```bash
 clang++ -O3 \
+        -DBUILDING_NODE_EXTENSION \
         -I./node_modules/emnapi/include \
         -L./node_modules/emnapi/lib/wasm32 \
         --target=wasm32 \

--- a/packages/emnapi/include/emnapi_common.h
+++ b/packages/emnapi/include/emnapi_common.h
@@ -2,23 +2,29 @@
 #define EMNAPI_INCLUDE_COMMON_H_
 
 #ifdef __EMSCRIPTEN__
-#define NAPI_EXTERN __attribute__((__import_module__("env")))
-
 #define EMNAPI_EXTERN __attribute__((__import_module__("env")))
 #else
-#define NAPI_EXTERN __attribute__((__import_module__("napi")))
-
 #define EMNAPI_EXTERN __attribute__((__import_module__("emnapi")))
 #endif
 
 #define EMNAPI_INTERNAL_EXTERN __attribute__((__import_module__("env")))
 
 #ifdef __cplusplus
+#ifndef EXTERN_C_START
 #define EXTERN_C_START extern "C" {
+#endif
+
+#ifndef EXTERN_C_END
 #define EXTERN_C_END }
+#endif
 #else
+#ifndef EXTERN_C_START
 #define EXTERN_C_START
+#endif
+
+#ifndef EXTERN_C_END
 #define EXTERN_C_END
+#endif
 #endif
 
 #endif

--- a/packages/emnapi/include/js_native_api.h
+++ b/packages/emnapi/include/js_native_api.h
@@ -23,13 +23,12 @@
 
 #include "js_native_api_types.h"
 
-#ifdef EMNAPI_UNMODIFIED_UPSTREAM
 // If you need __declspec(dllimport), either include <node_api.h> instead, or
 // define NAPI_EXTERN as __declspec(dllimport) on the compiler's command line.
 #ifndef NAPI_EXTERN
 #ifdef _WIN32
 #define NAPI_EXTERN __declspec(dllexport)
-#elif defined(__wasm32__)
+#elif defined(__wasm__)
 #define NAPI_EXTERN                                                            \
   __attribute__((visibility("default")))                                       \
   __attribute__((__import_module__("napi")))
@@ -37,20 +36,15 @@
 #define NAPI_EXTERN __attribute__((visibility("default")))
 #endif
 #endif
-#else
-#include "emnapi_common.h"
-#endif
 
 #define NAPI_AUTO_LENGTH SIZE_MAX
 
-#ifdef EMNAPI_UNMODIFIED_UPSTREAM
 #ifdef __cplusplus
 #define EXTERN_C_START extern "C" {
 #define EXTERN_C_END }
 #else
 #define EXTERN_C_START
 #define EXTERN_C_END
-#endif
 #endif
 
 EXTERN_C_START

--- a/packages/emnapi/include/js_native_api.h
+++ b/packages/emnapi/include/js_native_api.h
@@ -21,6 +21,12 @@
 #endif
 #endif
 
+#ifndef EMNAPI_UNMODIFIED_UPSTREAM
+#if !defined(NAPI_EXTERN) && defined(__EMSCRIPTEN__)
+#define NAPI_EXTERN __attribute__((__import_module__("env")))
+#endif
+#endif
+
 #include "js_native_api_types.h"
 
 // If you need __declspec(dllimport), either include <node_api.h> instead, or

--- a/packages/emnapi/include/node_api.h
+++ b/packages/emnapi/include/node_api.h
@@ -1,6 +1,16 @@
 #ifndef SRC_NODE_API_H_
 #define SRC_NODE_API_H_
 
+#ifndef EMNAPI_UNMODIFIED_UPSTREAM
+#ifndef BUILDING_NODE_EXTENSION
+#define BUILDING_NODE_EXTENSION
+#endif
+
+#if !defined(NAPI_EXTERN) && defined(__EMSCRIPTEN__)
+#define NAPI_EXTERN __attribute__((__import_module__("env")))
+#endif
+#endif
+
 #if defined(BUILDING_NODE_EXTENSION) && !defined(NAPI_EXTERN)
 #ifdef _WIN32
 // Building native addon against node

--- a/packages/emnapi/include/node_api.h
+++ b/packages/emnapi/include/node_api.h
@@ -1,14 +1,12 @@
 #ifndef SRC_NODE_API_H_
 #define SRC_NODE_API_H_
 
-#ifdef EMNAPI_UNMODIFIED_UPSTREAM
-#ifdef BUILDING_NODE_EXTENSION
+#if defined(BUILDING_NODE_EXTENSION) && !defined(NAPI_EXTERN)
 #ifdef _WIN32
 // Building native addon against node
 #define NAPI_EXTERN __declspec(dllimport)
-#elif defined(__wasm32__)
+#elif defined(__wasm__)
 #define NAPI_EXTERN __attribute__((__import_module__("napi")))
-#endif
 #endif
 #endif
 #include "js_native_api.h"
@@ -19,14 +17,11 @@ struct uv_loop_s;  // Forward declaration.
 #ifdef _WIN32
 #define NAPI_MODULE_EXPORT __declspec(dllexport)
 #else
-#ifdef EMNAPI_UNMODIFIED_UPSTREAM
-#define NAPI_MODULE_EXPORT __attribute__((visibility("default")))
-#else
 #ifdef __EMSCRIPTEN__
-#define NAPI_MODULE_EXPORT __attribute__((visibility("default"))) __attribute__((used))
+#define NAPI_MODULE_EXPORT                                                     \
+  __attribute__((visibility("default"))) __attribute__((used))
 #else
 #define NAPI_MODULE_EXPORT __attribute__((visibility("default")))
-#endif
 #endif
 #endif
 
@@ -59,18 +54,10 @@ typedef struct napi_module {
   NAPI_MODULE_INITIALIZER_X_HELPER(base, version)
 #define NAPI_MODULE_INITIALIZER_X_HELPER(base, version) base##version
 
-#ifdef EMNAPI_UNMODIFIED_UPSTREAM
-#ifdef __wasm32__
-#define NAPI_MODULE_INITIALIZER_BASE napi_register_wasm_v
-#else
-#define NAPI_MODULE_INITIALIZER_BASE napi_register_module_v
-#endif
-#else
 #ifdef __wasm__
 #define NAPI_MODULE_INITIALIZER_BASE napi_register_wasm_v
 #else
 #define NAPI_MODULE_INITIALIZER_BASE napi_register_module_v
-#endif
 #endif
 
 #define NODE_API_MODULE_GET_API_VERSION_BASE node_api_module_get_api_version_v
@@ -160,7 +147,7 @@ NAPI_EXTERN napi_status NAPI_CDECL napi_get_buffer_info(napi_env env,
                                                         napi_value value,
                                                         void** data,
                                                         size_t* length);
-#if !defined(EMNAPI_UNMODIFIED_UPSTREAM) || (defined(EMNAPI_UNMODIFIED_UPSTREAM) && !defined(__wasm32__))
+
 // Methods to manage simple async operations
 NAPI_EXTERN napi_status NAPI_CDECL
 napi_create_async_work(napi_env env,
@@ -176,7 +163,6 @@ NAPI_EXTERN napi_status NAPI_CDECL napi_queue_async_work(napi_env env,
                                                          napi_async_work work);
 NAPI_EXTERN napi_status NAPI_CDECL napi_cancel_async_work(napi_env env,
                                                           napi_async_work work);
-#endif  // __wasm32__
 
 // version management
 NAPI_EXTERN napi_status NAPI_CDECL
@@ -214,7 +200,6 @@ napi_close_callback_scope(napi_env env, napi_callback_scope scope);
 
 #if NAPI_VERSION >= 4
 
-#if !defined(EMNAPI_UNMODIFIED_UPSTREAM) || (defined(EMNAPI_UNMODIFIED_UPSTREAM) && !defined(__wasm32__))
 // Calling into JS from other threads
 NAPI_EXTERN napi_status NAPI_CDECL
 napi_create_threadsafe_function(napi_env env,
@@ -248,7 +233,6 @@ napi_unref_threadsafe_function(napi_env env, napi_threadsafe_function func);
 
 NAPI_EXTERN napi_status NAPI_CDECL
 napi_ref_threadsafe_function(napi_env env, napi_threadsafe_function func);
-#endif  // __wasm32__
 
 #endif  // NAPI_VERSION >= 4
 

--- a/packages/test/CMakeLists.txt
+++ b/packages/test/CMakeLists.txt
@@ -119,6 +119,9 @@ endif()
 
 if(IS_WASM)
 set(EMNAPI_FIND_NODE_ADDON_API ON)
+if(IS_EMSCRIPTEN)
+  add_compile_definitions("NAPI_EXTERN=__attribute__((__import_module__(\"env\")))")
+endif()
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../emnapi" "${CMAKE_CURRENT_BINARY_DIR}/emnapi")
 endif()
 

--- a/packages/test/CMakeLists.txt
+++ b/packages/test/CMakeLists.txt
@@ -117,13 +117,8 @@ else()
   set(COMMON_LINK_OPTIONS "")
 endif()
 
-add_compile_definitions("BUILDING_NODE_EXTENSION=1")
-
 if(IS_WASM)
 set(EMNAPI_FIND_NODE_ADDON_API ON)
-if(IS_EMSCRIPTEN)
-  add_compile_definitions("NAPI_EXTERN=__attribute__((__import_module__(\"env\")))")
-endif()
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../emnapi" "${CMAKE_CURRENT_BINARY_DIR}/emnapi")
 endif()
 

--- a/packages/test/CMakeLists.txt
+++ b/packages/test/CMakeLists.txt
@@ -117,6 +117,8 @@ else()
   set(COMMON_LINK_OPTIONS "")
 endif()
 
+add_compile_definitions("BUILDING_NODE_EXTENSION=1")
+
 if(IS_WASM)
 set(EMNAPI_FIND_NODE_ADDON_API ON)
 if(IS_EMSCRIPTEN)


### PR DESCRIPTION
https://github.com/nodejs/node/pull/49037

The update of node-api-headers may not be timely. Keep the built-in header file so that emnapi can respond to changes in Node-API at any time.

Additional suggestion to users:

- Always define `-DBUILDING_NODE_EXTENSION`
- Emscripten users should define `-DNAPI_EXTERN=__attribute__((__import_module__("env")))` manually since `napi` is the default module where Node.js wants to import symbols from. see https://github.com/emscripten-core/emscripten/issues/20035