### PR TITLE
do not include `js_native_api.h` in `emnapi.h`

### DIFF
--- a/packages/emnapi/include/emnapi.h
+++ b/packages/emnapi/include/emnapi.h
@@ -1,7 +1,8 @@
 #ifndef EMNAPI_INCLUDE_EMNAPI_H_
 #define EMNAPI_INCLUDE_EMNAPI_H_
 
-#include "js_native_api.h"
+#include <stdbool.h>
+#include "js_native_api_types.h"
 #include "emnapi_common.h"
 
 typedef enum {

--- a/packages/emnapi/src/async_cleanup_hook.c
+++ b/packages/emnapi/src/async_cleanup_hook.c
@@ -1,5 +1,5 @@
-#include "emnapi_internal.h"
 #include "node_api.h"
+#include "emnapi_internal.h"
 
 #if NAPI_VERSION >= 8
 

--- a/packages/emnapi/src/node_api.c
+++ b/packages/emnapi/src/node_api.c
@@ -1,5 +1,5 @@
-#include "emnapi_internal.h"
 #include "node_api.h"
+#include "emnapi_internal.h"
 
 #if EMNAPI_HAVE_THREADS
 #include "uv.h"

--- a/packages/test/buffer/binding.c
+++ b/packages/test/buffer/binding.c
@@ -1,8 +1,9 @@
+#include <node_api.h>
+
 #ifdef __wasm__
 #include <emnapi.h>
 #endif
 
-#include <node_api.h>
 #include "../common.h"
 
 void* malloc(size_t size);

--- a/packages/test/fnwrap/myobject.cc
+++ b/packages/test/fnwrap/myobject.cc
@@ -1,7 +1,7 @@
+#include "myobject.h"
 #ifdef __wasm__
 #include <emnapi.h>
 #endif
-#include "myobject.h"
 #include "../common.h"
 
 #if !(!defined(__wasm__) || (defined(__EMSCRIPTEN__) || defined(__wasi__)))

--- a/packages/test/typedarray/binding.c
+++ b/packages/test/typedarray/binding.c
@@ -1,8 +1,9 @@
+#include <js_native_api.h>
+
 #ifdef __wasm__
 #include <emnapi.h>
 #endif
 
-#include <js_native_api.h>
 // #include <string.h>
 // #include <stdlib.h>
 #include "../common.h"


### PR DESCRIPTION
from #84 

User side change: `emnapi.h` should go after `node_api.h` or `js_native_api.h` due to `NAPI_VERSION` is defined in `js_native_api.h`
