### PR TITLE
feat: add a prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
+    "prepare": "npm run build",
     "build": "npm run build --workspaces --if-present",
     "build:main": "npm run build -w packages/emnapi",
     "build:core": "npm run build -w packages/core",


### PR DESCRIPTION
a `prepare` script is a nice to have addition, it is run automatically whenever the package is installed

it allows to install dev versions directly from github and to use `npm link` locally