### PR TITLE
feat: add new option to allow waiting thread start before thread-spawn return

### DIFF
--- a/packages/core/src/emnapi/index.d.ts
+++ b/packages/core/src/emnapi/index.d.ts
@@ -69,6 +69,7 @@ export declare type BaseCreateOptions = {
   nodeBinding?: NodeBinding
   reuseWorker?: boolean
   asyncWorkPoolSize?: number
+  waitThreadStart?: boolean
   onCreateWorker?: (info: CreateWorkerInfo) => any
   print?: (str: string) => void
   printErr?: (str: string) => void

--- a/packages/emnapi/src/core/scope.d.ts
+++ b/packages/emnapi/src/core/scope.d.ts
@@ -5,6 +5,7 @@ declare interface CreateOptions {
   childThread?: boolean
   reuseWorker?: boolean
   asyncWorkPoolSize?: number
+  waitThreadStart?: boolean
   onCreateWorker?: () => any
   print?: (str: string) => void
   printErr?: (str: string) => void

--- a/packages/test/util.js
+++ b/packages/test/util.js
@@ -50,6 +50,7 @@ function loadPath (request, options) {
           : -RUNTIME_UV_THREADPOOL_SIZE,
         filename: request,
         reuseWorker: true,
+        waitThreadStart: true,
         onCreateWorker () {
           return new Worker(join(__dirname, './worker.js'), {
             env: process.env,


### PR DESCRIPTION
https://github.com/WebAssembly/wasi-threads?tab=readme-ov-file#design-choice-pthreads

> 4. in pthread_create, call wasi_thread_spawn with the configured start_args and use atomic.wait to wait for the start_args->thread->tid value to change (note that for web polyfills this may not be necessary since creation of web workers is not synchronous)

Not available on browser.