### PR TITLE
feat: `reuseWorker` strict mode

### DIFF
--- a/packages/core/src/emnapi/index.d.ts
+++ b/packages/core/src/emnapi/index.d.ts
@@ -1,5 +1,5 @@
 import type { Context } from '@emnapi/runtime'
-import type { ThreadManager } from '@emnapi/wasi-threads'
+import type { ThreadManager, ThreadManagerOptionsMain, MainThreadBaseOptions } from '@emnapi/wasi-threads'
 
 /** @public */
 export declare interface PointerInfo {
@@ -65,15 +65,16 @@ export declare interface NodeBinding {
 /** @public */
 export declare interface CreateWorkerInfo {
   type: 'thread' | 'async-work'
+  name: string
 }
 
 /** @public */
 export declare type BaseCreateOptions = {
   filename?: string
   nodeBinding?: NodeBinding
-  reuseWorker?: boolean
+  reuseWorker?: ThreadManagerOptionsMain['reuseWorker']
   asyncWorkPoolSize?: number
-  waitThreadStart?: boolean | number
+  waitThreadStart?: MainThreadBaseOptions['waitThreadStart']
   onCreateWorker?: (info: CreateWorkerInfo) => any
   print?: (str: string) => void
   printErr?: (str: string) => void

--- a/packages/core/src/load.ts
+++ b/packages/core/src/load.ts
@@ -1,4 +1,4 @@
-import { type WASIInstance, WASIThreads } from '@emnapi/wasi-threads'
+import { type WASIInstance, WASIThreads, isSharedArrayBuffer } from '@emnapi/wasi-threads'
 import { type InputType, load, loadSync } from './util'
 import { createNapiModule } from './emnapi/index'
 import type { CreateOptions, NapiModule } from './emnapi/index'
@@ -168,12 +168,14 @@ function loadNapiModuleImpl (loadFn: Function, userNapiModule: NapiModule | unde
       return ret
     }
 
-    if (napiModule.PThread.shouldPreloadWorkers()) {
-      const poolReady = napiModule.PThread.loadWasmModuleToAllWorkers()
-      if (loadFn === loadCallback) {
-        return poolReady.then(emnapiInit)
+    if (typeof originalInstance.exports.wasi_thread_start === 'function' && isSharedArrayBuffer(memory.buffer)) {
+      if (napiModule.PThread.shouldPreloadWorkers()) {
+        const poolReady = napiModule.PThread.loadWasmModuleToAllWorkers()
+        if (loadFn === loadCallback) {
+          return poolReady.then(emnapiInit)
+        }
+        return emnapiInit()
       }
-      return emnapiInit()
     }
 
     return emnapiInit()

--- a/packages/core/src/load.ts
+++ b/packages/core/src/load.ts
@@ -1,4 +1,4 @@
-import { type WASIInstance, WASIThreads, isSharedArrayBuffer } from '@emnapi/wasi-threads'
+import { type WASIInstance, WASIThreads } from '@emnapi/wasi-threads'
 import { type InputType, load, loadSync } from './util'
 import { createNapiModule } from './emnapi/index'
 import type { CreateOptions, NapiModule } from './emnapi/index'

--- a/packages/emnapi/README.md
+++ b/packages/emnapi/README.md
@@ -952,7 +952,17 @@ instantiateNapiModule(input, {
    * Reuse the thread worker after thread exit to avoid re-creatation
    * @defaultValue false
    */
-  reuseWorker: true,
+  reuseWorker: {
+    /**
+     * @see {@link https://emscripten.org/docs/tools_reference/settings_reference.html#pthread-pool-size | PTHREAD_POOL_SIZE}
+     */
+    size: 0,
+
+    /**
+     * @see {@link https://emscripten.org/docs/tools_reference/settings_reference.html#pthread-pool-size-strict | PTHREAD_POOL_SIZE_STRICT}
+     */
+    strict: false
+  },
 
   onCreateWorker () {
     return new Worker('./worker.js')

--- a/packages/emnapi/src/core/index.ts
+++ b/packages/emnapi/src/core/index.ts
@@ -1,4 +1,4 @@
-import { napiModule } from 'emnapi:shared'
+import { napiModule, PThread } from 'emnapi:shared'
 
 import * as asyncMod from './async'
 import * as memoryMod from './memory'
@@ -41,6 +41,7 @@ emnapiAWST.init()
 emnapiExternalMemory.init()
 emnapiString.init()
 emnapiTSFN.init()
+PThread.init()
 
 napiModule.emnapi.syncMemory = emnapiMod.$emnapiSyncMemory
 napiModule.emnapi.getMemoryAddress = emnapiMod.$emnapiGetMemoryAddress

--- a/packages/emnapi/src/core/init.ts
+++ b/packages/emnapi/src/core/init.ts
@@ -259,5 +259,4 @@ export var PThread = new ThreadManager(
       }
 )
 
-PThread.init()
 napiModule.PThread = PThread

--- a/packages/emnapi/src/core/init.ts
+++ b/packages/emnapi/src/core/init.ts
@@ -36,7 +36,6 @@ declare const process: any
 
 export var ENVIRONMENT_IS_NODE = typeof process === 'object' && process !== null && typeof process.versions === 'object' && process.versions !== null && typeof process.versions.node === 'string'
 export var ENVIRONMENT_IS_PTHREAD = Boolean(options.childThread)
-export var reuseWorker = Boolean(options.reuseWorker)
 export var waitThreadStart = typeof options.waitThreadStart === 'number' ? options.waitThreadStart : Boolean(options.waitThreadStart)
 
 export var wasmInstance: WebAssembly.Instance
@@ -69,7 +68,7 @@ export var napiModule: INapiModule = {
   emnapi: {},
   loaded: false,
   filename: '',
-  childThread: Boolean(options.childThread),
+  childThread: ENVIRONMENT_IS_PTHREAD,
 
   initWorker: undefined!,
   executeAsyncWork: undefined!,
@@ -244,15 +243,21 @@ function emnapiAddSendListener (worker: any): boolean {
 
 napiModule.emnapi.addSendListener = emnapiAddSendListener
 
-export var PThread = new ThreadManager({
-  printErr: err,
-  beforeLoad: (worker) => {
-    emnapiAddSendListener(worker)
-  },
-  reuseWorker,
-  onCreateWorker: onCreateWorker as ThreadManagerOptions['onCreateWorker'] ?? (() => {
-    throw new Error('options.onCreateWorker` is not provided')
-  })
-})
+export var PThread = new ThreadManager(
+  ENVIRONMENT_IS_PTHREAD
+    ? {
+        printErr: err,
+        childThread: true
+      }
+    : {
+        printErr: err,
+        beforeLoad: (worker) => {
+          emnapiAddSendListener(worker)
+        },
+        reuseWorker: options.reuseWorker,
+        onCreateWorker: onCreateWorker as ThreadManagerOptionsMain['onCreateWorker']
+      }
+)
 
+PThread.init()
 napiModule.PThread = PThread

--- a/packages/emnapi/src/core/scope.d.ts
+++ b/packages/emnapi/src/core/scope.d.ts
@@ -3,9 +3,9 @@ declare interface CreateOptions {
   filename?: string
   nodeBinding?: NodeBinding
   childThread?: boolean
-  reuseWorker?: boolean
+  reuseWorker?: ThreadManagerOptionsMain['reuseWorker']
   asyncWorkPoolSize?: number
-  waitThreadStart?: boolean | number
+  waitThreadStart?: MainThreadBaseOptions['waitThreadStart']
   onCreateWorker?: () => any
   print?: (str: string) => void
   printErr?: (str: string) => void
@@ -15,7 +15,8 @@ declare interface CreateOptions {
 // factory parameter
 declare const options: CreateOptions
 
-declare type ThreadManagerOptions = import('../../../wasi-threads/lib/typings/index').ThreadManagerOptions
+declare type MainThreadBaseOptions = import('../../../wasi-threads/lib/typings/index').MainThreadBaseOptions
+declare type ThreadManagerOptionsMain = import('../../../wasi-threads/lib/typings/index').ThreadManagerOptionsMain
 declare const ThreadManager: typeof import('../../../wasi-threads/lib/typings/index').ThreadManager
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 declare type ThreadManager = import('../../../wasi-threads/lib/typings/index').ThreadManager

--- a/packages/test/util.js
+++ b/packages/test/util.js
@@ -49,7 +49,10 @@ function loadPath (request, options) {
           ? RUNTIME_UV_THREADPOOL_SIZE
           : -RUNTIME_UV_THREADPOOL_SIZE,
         filename: request,
-        reuseWorker: true,
+        reuseWorker: {
+          size: RUNTIME_UV_THREADPOOL_SIZE * 4,
+          strict: true
+        },
         waitThreadStart: 1000,
         onCreateWorker () {
           return new Worker(join(__dirname, './worker.js'), {

--- a/packages/test/util.js
+++ b/packages/test/util.js
@@ -45,21 +45,26 @@ function loadPath (request, options) {
       })
       const napiModule = createNapiModule({
         context,
+        filename: request,
         asyncWorkPoolSize: process.env.EMNAPI_TEST_WASI_THREADS
           ? RUNTIME_UV_THREADPOOL_SIZE
           : -RUNTIME_UV_THREADPOOL_SIZE,
-        filename: request,
-        reuseWorker: {
-          size: RUNTIME_UV_THREADPOOL_SIZE * 4,
-          strict: true
-        },
-        waitThreadStart: 1000,
-        onCreateWorker () {
-          return new Worker(join(__dirname, './worker.js'), {
-            env: process.env,
-            execArgv: ['--experimental-wasi-unstable-preview1']
-          })
-        },
+        ...(process.env.EMNAPI_TEST_WASI_THREADS
+          ? {
+              reuseWorker: {
+                size: RUNTIME_UV_THREADPOOL_SIZE * 4,
+                strict: true
+              },
+              waitThreadStart: 1000,
+              onCreateWorker () {
+                return new Worker(join(__dirname, './worker.js'), {
+                  env: process.env,
+                  execArgv: ['--experimental-wasi-unstable-preview1']
+                })
+              }
+            }
+          : {}
+        ),
         ...(options || {})
       })
 

--- a/packages/wasi-threads/README.md
+++ b/packages/wasi-threads/README.md
@@ -40,7 +40,7 @@ This package makes [wasi-threads proposal](https://github.com/WebAssembly/wasi-t
   const { WASI } = require('wasi')
   const Worker = require('worker_threads')
   const { WASIThreads } = require('@emnapi/wasi-threads')
-  
+
   const wasi = new WASI({
     version: 'preview1'
   })
@@ -70,12 +70,14 @@ This package makes [wasi-threads proposal](https://github.com/WebAssembly/wasi-t
     wasi_snapshot_preview1: wasi.wasiImport,
     ...wasiThreads.getImportObject()
   })
-  
+
+  wasiThreads.setup(instance, module, memory)
+  await wasiThreads.preloadWorkers()
+
   if (typeof instance.exports._start === 'function') {
-    const { exitCode } = wasiThreads.start(instance, module, memory)
-    return exitCode
+    return wasi.start(instance)
   } else {
-    instance = wasiThreads.initialize(instance, module, memory)
+    wasi.initialize(instance)
     // instance.exports.exported_wasm_function()
   }
 })

--- a/packages/wasi-threads/src/index.ts
+++ b/packages/wasi-threads/src/index.ts
@@ -29,6 +29,6 @@ export type { ThreadMessageHandlerOptions } from './worker'
 
 export { createInstanceProxy } from './proxy'
 
-export { isTrapError } from './util'
+export { isTrapError, isSharedArrayBuffer } from './util'
 
 export type { LoadPayload } from './command'

--- a/packages/wasi-threads/src/index.ts
+++ b/packages/wasi-threads/src/index.ts
@@ -1,4 +1,13 @@
-export type { ThreadManagerOptions, WorkerLike, WorkerMessageEvent, WorkerFactory } from './thread-manager'
+export type {
+  ReuseWorkerOptions,
+  ThreadManagerOptionsBase,
+  ThreadManagerOptionsMain,
+  ThreadManagerOptionsChild,
+  ThreadManagerOptions,
+  WorkerLike,
+  WorkerMessageEvent,
+  WorkerFactory
+} from './thread-manager'
 export { ThreadManager } from './thread-manager'
 
 export type {

--- a/packages/wasi-threads/src/thread-manager.ts
+++ b/packages/wasi-threads/src/thread-manager.ts
@@ -149,6 +149,8 @@ export class ThreadManager {
         while (pthreadPoolSize--) {
           const worker = this.allocateUnusedWorker()
           if (ENVIRONMENT_IS_NODE) {
+            // https://github.com/nodejs/node/issues/53036
+            (worker as NodeWorker).once('message', () => {});
             (worker as NodeWorker).unref()
           }
         }

--- a/packages/wasi-threads/src/thread-manager.ts
+++ b/packages/wasi-threads/src/thread-manager.ts
@@ -19,7 +19,14 @@ export type WorkerFactory = (ctx: { type: string; name: string }) => WorkerLike
 
 /** @public */
 export interface ReuseWorkerOptions {
+  /**
+   * @see {@link https://emscripten.org/docs/tools_reference/settings_reference.html#pthread-pool-size | PTHREAD_POOL_SIZE}
+   */
   size: number
+
+  /**
+   * @see {@link https://emscripten.org/docs/tools_reference/settings_reference.html#pthread-pool-size-strict | PTHREAD_POOL_SIZE_STRICT}
+   */
   strict?: boolean
 }
 

--- a/packages/wasi-threads/src/thread-manager.ts
+++ b/packages/wasi-threads/src/thread-manager.ts
@@ -1,5 +1,5 @@
 import type { Worker as NodeWorker } from 'worker_threads'
-import { ENVIRONMENT_IS_NODE } from './util'
+import { ENVIRONMENT_IS_NODE, isSharedArrayBuffer } from './util'
 import { type MessageEventData, createMessage, type CommandPayloadMap, type CleanupThreadPayload } from './command'
 
 /** @public */
@@ -54,7 +54,7 @@ export interface ThreadManagerOptionsChild extends ThreadManagerOptionsBase {
 const WASI_THREADS_MAX_TID = 0x1FFFFFFF
 
 export function checkSharedWasmMemory (wasmMemory?: WebAssembly.Memory | null): void {
-  if (typeof SharedArrayBuffer === 'undefined' || (wasmMemory && !(wasmMemory.buffer instanceof SharedArrayBuffer))) {
+  if (wasmMemory ? !isSharedArrayBuffer(wasmMemory.buffer) : (typeof SharedArrayBuffer === 'undefined')) {
     throw new Error(
       'Multithread features require shared wasm memory. ' +
       'Try to compile with `-matomics -mbulk-memory` and use `--import-memory --shared-memory` during linking'

--- a/packages/wasi-threads/src/thread-manager.ts
+++ b/packages/wasi-threads/src/thread-manager.ts
@@ -149,8 +149,6 @@ export class ThreadManager {
         while (pthreadPoolSize--) {
           const worker = this.allocateUnusedWorker()
           if (ENVIRONMENT_IS_NODE) {
-            // https://github.com/nodejs/node/issues/53036
-            (worker as NodeWorker).once('message', () => {});
             (worker as NodeWorker).unref()
           }
         }

--- a/packages/wasi-threads/src/util.ts
+++ b/packages/wasi-threads/src/util.ts
@@ -66,6 +66,14 @@ export function deserizeErrorFromBuffer (sab: SharedArrayBuffer): Error | null {
 }
 
 /** @public */
+export function isSharedArrayBuffer (value: any): value is SharedArrayBuffer {
+  return (
+    (typeof SharedArrayBuffer === 'function' && value instanceof SharedArrayBuffer) ||
+    (Object.prototype.toString.call(value.constructor) === '[object SharedArrayBuffer]')
+  )
+}
+
+/** @public */
 export function isTrapError (e: Error): e is WebAssembly.RuntimeError {
   try {
     return e instanceof _WebAssembly.RuntimeError

--- a/packages/wasi-threads/src/wasi-threads.ts
+++ b/packages/wasi-threads/src/wasi-threads.ts
@@ -1,6 +1,6 @@
 import { ENVIRONMENT_IS_NODE, deserizeErrorFromBuffer, getPostMessage, isTrapError } from './util'
 import { checkSharedWasmMemory, ThreadManager } from './thread-manager'
-import type { WorkerMessageEvent, ThreadManagerOptions } from './thread-manager'
+import type { WorkerMessageEvent, ThreadManagerOptions, ThreadManagerOptionsMain } from './thread-manager'
 import { type CommandPayloadMap, type MessageEventData, createMessage, type SpawnThreadPayload } from './command'
 import { createInstanceProxy } from './proxy'
 
@@ -30,7 +30,7 @@ export interface MainThreadOptionsWithThreadManager extends MainThreadBaseOption
 }
 
 /** @public */
-export interface MainThreadOptionsCreateThreadManager extends MainThreadBaseOptions, ThreadManagerOptions {}
+export interface MainThreadOptionsCreateThreadManager extends MainThreadBaseOptions, ThreadManagerOptionsMain {}
 
 /** @public */
 export type MainThreadOptions = MainThreadOptionsWithThreadManager | MainThreadOptionsCreateThreadManager

--- a/packages/wasi-threads/src/wasi-threads.ts
+++ b/packages/wasi-threads/src/wasi-threads.ts
@@ -1,6 +1,6 @@
 import { ENVIRONMENT_IS_NODE, deserizeErrorFromBuffer, getPostMessage, isTrapError } from './util'
 import { checkSharedWasmMemory, ThreadManager } from './thread-manager'
-import type { WorkerMessageEvent, ThreadManagerOptions, ThreadManagerOptionsMain } from './thread-manager'
+import type { WorkerMessageEvent, ThreadManagerOptions, ThreadManagerOptionsMain, WorkerLike } from './thread-manager'
 import { type CommandPayloadMap, type MessageEventData, createMessage, type SpawnThreadPayload } from './command'
 import { createInstanceProxy } from './proxy'
 
@@ -99,6 +99,7 @@ export class WASIThreads {
     } else {
       if (!this.childThread) {
         this.PThread = new ThreadManager(options as ThreadManagerOptions)
+        this.PThread.init()
       }
     }
 
@@ -262,6 +263,13 @@ export class WASIThreads {
     if (this.PThread) {
       this.PThread.setup(wasmModule, wasmMemory)
     }
+  }
+
+  public preloadWorkers (): Promise<WorkerLike[]> {
+    if (this.PThread) {
+      return this.PThread.preloadWorkers()
+    }
+    return Promise.resolve([])
   }
 
   /**


### PR DESCRIPTION
https://emscripten.org/docs/tools_reference/settings_reference.html#pthread-pool-size

```js
instantiateNapiModule({
  /**
   * equivalent to { size: 0, strict: false }
   */
  reuseWorker: true,

  reuseWorker: {
    size: 4, // equivalent to emscripten's PTHREAD_POOL_SIZE
    strict: true // equivalent to emscripten's PTHREAD_POOL_SIZE_STRICT=2
  }
})
```

If `size > 0`, only asynchronous loading API (`instantiateNapiModule` / `loadNapiModule`) can guarantee thread pool ready before emnapi initialization.