### PR TITLE
add checks for message channel usage in web runtime

### DIFF
--- a/packages/runtime/src/Context.ts
+++ b/packages/runtime/src/Context.ts
@@ -92,7 +92,9 @@ class NodejsWaitingRequestCounter {
 
   public increase (): void {
     if (this.count === 0) {
-      this.refHandle.ref()
+      if (this.refHandle.ref) {
+        this.refHandle.ref()
+      }
     }
     this.count++
   }
@@ -100,7 +102,9 @@ class NodejsWaitingRequestCounter {
   public decrease (): void {
     if (this.count === 0) return
     if (this.count === 1) {
-      this.refHandle.unref()
+      if (this.refHandle.unref) {
+        this.refHandle.unref()
+      }
     }
     this.count--
   }


### PR DESCRIPTION
Deno/Web MessageChannel does not support ref and unref as node does. A simple check if the function actually exists will probably fix some issues folks are having trying to utilize this in other modern runtimes. 

https://github.com/lovell/sharp/issues/3912#issuecomment-1866261154

https://developer.mozilla.org/en-US/docs/Web/API/MessagePort

https://nodejs.org/api/worker_threads.html#portref