### PR TITLE
fix(wasi): avoid deadlock caused by child thread abort when the main thread is in `Atomics.wait`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,12 +18,12 @@ on:
   workflow_dispatch:
 
 env:
-  WASI_VERSION: '25'
-  WASI_VERSION_FULL: '25.0'
-  WASI_SDK_PATH: './wasi-sdk-25.0'
-  EM_VERSION: '3.1.64'
+  WASI_VERSION: '27'
+  WASI_VERSION_FULL: '27.0'
+  WASI_SDK_PATH: './wasi-sdk-27.0'
+  EM_VERSION: '4.0.1'
   EM_CACHE_FOLDER: 'emsdk-cache'
-  NODE_VERSION: '22.15.0'
+  NODE_VERSION: '22.16.0'
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,7 +77,7 @@ jobs:
 
     - uses: actions/setup-node@v3
       with:
-        node-version: ${{ env.NODE_VERSION }}
+        node-version: ${{ matrix.target == 'wasm64-unknown-emscripten' && '24.5.0' || env.NODE_VERSION }}
         registry-url: 'https://registry.npmjs.org'
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/packages/core/src/worker.ts
+++ b/packages/core/src/worker.ts
@@ -1,7 +1,8 @@
 import {
   ThreadMessageHandler,
   type ThreadMessageHandlerOptions,
-  type LoadPayload
+  type LoadPayload,
+  type WorkerMessageEvent
 } from '@emnapi/wasi-threads'
 import type { NapiModule } from './emnapi/index'
 import type { InstantiatedSource } from './load'
@@ -21,7 +22,24 @@ export class MessageHandler extends ThreadMessageHandler {
     if (typeof options.onLoad !== 'function') {
       throw new TypeError('options.onLoad is not a function')
     }
-    super(options)
+    const userOnError = options.onError
+    super({
+      ...options,
+      onError: (err, type) => {
+        const emnapi_thread_crashed = this.instance?.exports.emnapi_thread_crashed as () => void
+        if (typeof emnapi_thread_crashed === 'function') {
+          emnapi_thread_crashed()
+        } /* else {
+          tryWakeUpPthreadJoin(this.instance!)
+        } */
+
+        if (typeof userOnError === 'function') {
+          userOnError(err, type)
+        } else {
+          throw err
+        }
+      }
+    })
     this.napiModule = undefined
   }
 
@@ -38,21 +56,39 @@ export class MessageHandler extends ThreadMessageHandler {
     return source
   }
 
-  public override handle (e: any): void {
+  public override handle (e: WorkerMessageEvent): void {
     super.handle(e)
     if (e?.data?.__emnapi__) {
       const type = e.data.__emnapi__.type
       const payload = e.data.__emnapi__.payload
-
-      if (type === 'async-worker-init') {
-        this.handleAfterLoad(e, () => {
-          this.napiModule!.initWorker(payload.arg)
-        })
-      } else if (type === 'async-work-execute') {
-        this.handleAfterLoad(e, () => {
-          this.napiModule!.executeAsyncWork(payload.work)
-        })
+      try {
+        if (type === 'async-worker-init') {
+          this.handleAfterLoad(e, () => {
+            this.napiModule!.initWorker(payload.arg)
+          })
+        } else if (type === 'async-work-execute') {
+          this.handleAfterLoad(e, () => {
+            this.napiModule!.executeAsyncWork(payload.work)
+          })
+        }
+      } catch (err) {
+        this.onError(err, type)
       }
     }
   }
 }
+
+// function tryWakeUpPthreadJoin (instance: WebAssembly.Instance): void {
+//   // https://github.com/WebAssembly/wasi-libc/blob/574b88da481569b65a237cb80daf9a2d5aeaf82d/libc-top-half/musl/src/thread/pthread_join.c#L18-L21
+//   const pthread_self = instance.exports.pthread_self as () => number
+//   const memory = instance.exports.memory as WebAssembly.Memory
+//   if (typeof pthread_self === 'function') {
+//     const selfThread = pthread_self()
+//     if (selfThread && memory) {
+//       // https://github.com/WebAssembly/wasi-libc/blob/574b88da481569b65a237cb80daf9a2d5aeaf82d/libc-top-half/musl/src/internal/pthread_impl.h#L45
+//       const detatchState = new Int32Array(memory.buffer, selfThread + 7 * 4 /** detach_state */, 1)
+//       Atomics.store(detatchState, 0, 0)
+//       Atomics.notify(detatchState, 0, Infinity)
+//     }
+//   }
+// }

--- a/packages/emnapi/CMakeLists.txt
+++ b/packages/emnapi/CMakeLists.txt
@@ -61,6 +61,7 @@ set(ENAPI_BASIC_SRC
   "${CMAKE_CURRENT_SOURCE_DIR}/src/node_api.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/async_cleanup_hook.c"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/async_context.c"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/wasi_wait.c"
 )
 set(EMNAPI_THREADS_SRC
   "${CMAKE_CURRENT_SOURCE_DIR}/src/async_work.c"

--- a/packages/emnapi/README.md
+++ b/packages/emnapi/README.md
@@ -816,8 +816,9 @@ Now emnapi has 3 implementations of async work and 2 implementations of TSFN:
 There are some limitations on browser about wasi-libc's pthread implementation, for example
 `pthread_mutex_lock` may call `__builtin_wasm_memory_atomic_wait32`(`memory.atomic.wait32`)
 which is disallowed in browser JS main thread. While Emscripten's pthread implementation
-has considered usage in browser. If you need to run your addon with multithreaded features on browser,
-we recommend you use Emscripten A & D, or bare wasm32 C & E.
+has considered usage in browser. This issue can be solved by upgrading `wasi-sdk` to v26+
+and emnapi v1.5.0+ then pass `--export=emnapi_thread_crashed` to the linker. If you need to
+run your addon with multithreaded features, we recommend you use A & D or C & E.
 
 Note: For browsers, all the multithreaded features relying on Web Workers (Emscripten pthread also relying on Web Workers)
 require cross-origin isolation to enable `SharedArrayBuffer`. You can make a page cross-origin isolated
@@ -879,6 +880,7 @@ elseif(CMAKE_C_COMPILER_TARGET STREQUAL "wasm32-wasi-threads")
     "-Wl,--export-if-defined=node_api_module_get_api_version_v1"
     "-Wl,--export=malloc"
     "-Wl,--export=free"
+    "-Wl,--export=emnapi_thread_crashed"
     "-Wl,--import-undefined"
     "-Wl,--export-table"
   )

--- a/packages/emnapi/common.gypi
+++ b/packages/emnapi/common.gypi
@@ -310,6 +310,7 @@
               'src/async_cleanup_hook.c',
               'src/async_context.c',
               'src/async_work.c',
+              'src/wasi_wait.c',
               'src/threadsafe_function.c',
               'src/uv/uv-common.c',
               'src/uv/threadpool.c',
@@ -370,6 +371,16 @@
                         '-Wl,--import-memory',
                         '-Wl,--shared-memory',
                       ]
+                    },
+                  }],
+                  ['OS == "wasi"', {
+                    'ldflags': [
+                      '-Wl,--export=emnapi_thread_crashed',
+                    ],
+                    'xcode_settings': {
+                      'OTHER_LDFLAGS': [
+                        '-Wl,--export=emnapi_thread_crashed',
+                      ],
                     },
                   }],
                   ['OS != "wasi"', {

--- a/packages/emnapi/emnapi.gyp
+++ b/packages/emnapi/emnapi.gyp
@@ -55,6 +55,7 @@
         'src/node_api.c',
         'src/async_cleanup_hook.c',
         'src/async_context.c',
+        'src/wasi_wait.c',
       ],
       'link_settings': {
         'target_conditions': [
@@ -88,6 +89,22 @@
             ]
           },
         }],
+        ['OS == "wasi"', {
+          'link_settings': {
+            'target_conditions': [
+              ['_type == "executable"', {
+                'ldflags': [
+                  '-Wl,--export=emnapi_thread_crashed',
+                ],
+                'xcode_settings': {
+                  'OTHER_LDFLAGS': [
+                    '-Wl,--export=emnapi_thread_crashed',
+                  ],
+                },
+              }],
+            ]
+          },
+        }],
       ]
     },
     {
@@ -98,6 +115,7 @@
         'src/node_api.c',
         'src/async_cleanup_hook.c',
         'src/async_context.c',
+        'src/wasi_wait.c',
 
         'src/uv/uv-common.c',
         'src/uv/threadpool.c',

--- a/packages/emnapi/src/core/async.ts
+++ b/packages/emnapi/src/core/async.ts
@@ -67,11 +67,6 @@ var uvThreadpoolReady: Promise<void> & { ready: boolean } = new Promise<void>((r
 }) as any
 uvThreadpoolReady.ready = false
 
-/** @__sig i */
-export function _emnapi_is_main_browser_thread (): number {
-  return (typeof window !== 'undefined' && typeof document !== 'undefined' && !ENVIRONMENT_IS_NODE) ? 1 : 0
-}
-
 /** @__sig vppi */
 export function _emnapi_after_uvthreadpool_ready (callback: number, q: number, type: number): void {
   if (uvThreadpoolReady.ready) {

--- a/packages/emnapi/src/core/init.ts
+++ b/packages/emnapi/src/core/init.ts
@@ -109,10 +109,12 @@ export var napiModule: INapiModule = {
           const moduleHandle = scope.add(napiModule)
           instance.exports[nodeRegisterModuleSymbol](to64('exportsHandle'), to64('moduleHandle'), to64('5'))
         } catch (err) {
+          if (err !== 'unwind') {
+            throw err
+          }
+        } finally {
           emnapiCtx.isolate.closeScope(scope)
-          throw err
         }
-        emnapiCtx.isolate.closeScope(scope)
         napiModule.loaded = true
         delete napiModule.envObject
         return napiModule.exports
@@ -150,6 +152,10 @@ export var napiModule: INapiModule = {
           const napiValue = napi_register_wasm_v1(to64('_envObject.id'), to64('exportsHandle'))
           napiModule.exports = (!napiValue) ? exports : emnapiCtx.jsValueFromNapiValue(napiValue)!
         })
+      } catch (e) {
+        if (e !== 'unwind') {
+          throw e
+        }
       } finally {
         emnapiCtx.closeScope(envObject, scope)
       }

--- a/packages/emnapi/src/emnapi_internal.h
+++ b/packages/emnapi/src/emnapi_internal.h
@@ -105,6 +105,11 @@ EMNAPI_INTERNAL_EXTERN void _emnapi_env_unref(napi_env env);
 EMNAPI_INTERNAL_EXTERN void _emnapi_ctx_increase_waiting_request_counter();
 EMNAPI_INTERNAL_EXTERN void _emnapi_ctx_decrease_waiting_request_counter();
 
+EMNAPI_INTERNAL_EXTERN int _emnapi_is_main_browser_thread();
+EMNAPI_INTERNAL_EXTERN int _emnapi_is_main_runtime_thread();
+EMNAPI_INTERNAL_EXTERN double _emnapi_get_now();
+EMNAPI_INTERNAL_EXTERN void _emnapi_unwind();
+
 #if defined(__EMSCRIPTEN_PTHREADS__) || defined(_REENTRANT)
 #define EMNAPI_HAVE_THREADS 1
 #else

--- a/packages/emnapi/src/emscripten/init.ts
+++ b/packages/emnapi/src/emscripten/init.ts
@@ -80,10 +80,12 @@ export function emnapiInit (options: InitOptions): any {
       const moduleHandle = scope.add(emnapiModule)
       Module[emscriptenExportedSymbol](to64('exportsHandle'), to64('moduleHandle'), to64('5'))
     } catch (err) {
+      if (err !== 'unwind') {
+        throw err
+      }
+    } finally {
       emnapiCtx.isolate.closeScope(scope)
-      throw err
     }
-    emnapiCtx.isolate.closeScope(scope)
     emnapiModule.loaded = true
     delete emnapiModule.envObject
     return emnapiModule.exports
@@ -118,10 +120,12 @@ NODE_MODULE_VERSION ${NODE_MODULE_VERSION}.`)
       emnapiModule.exports = (!napiValue) ? exports : emnapiCtx.jsValueFromNapiValue(napiValue)!
     })
   } catch (err) {
+    if (err !== 'unwind') {
+      throw err
+    }
+  } finally {
     emnapiCtx.closeScope(envObject, scope)
-    throw err
   }
-  emnapiCtx.closeScope(envObject, scope)
   emnapiModule.loaded = true
   delete emnapiModule.envObject
   return emnapiModule.exports

--- a/packages/emnapi/src/util.ts
+++ b/packages/emnapi/src/util.ts
@@ -1,4 +1,4 @@
-import { runtimeKeepalivePop, runtimeKeepalivePush } from 'emscripten:runtime'
+import { ENVIRONMENT_IS_NODE, ENVIRONMENT_IS_PTHREAD, runtimeKeepalivePop, runtimeKeepalivePush } from 'emscripten:runtime'
 import { from64, makeSetValue, makeDynCall } from 'emscripten:parse-tools'
 import { emnapiCtx } from 'emnapi:shared'
 
@@ -117,6 +117,34 @@ export function _emnapi_ctx_increase_waiting_request_counter (): void {
  */
 export function _emnapi_ctx_decrease_waiting_request_counter (): void {
   emnapiCtx.decreaseWaitingRequestCounter()
+}
+
+/**
+ * @__sig i
+ */
+export function _emnapi_is_main_runtime_thread (): number {
+  return ENVIRONMENT_IS_PTHREAD ? 0 : 1
+}
+
+/**
+ * @__sig i
+ */
+export function _emnapi_is_main_browser_thread (): number {
+  return (typeof window !== 'undefined' && typeof document !== 'undefined' && !ENVIRONMENT_IS_NODE) ? 1 : 0
+}
+
+/**
+ * @__sig v
+ */
+export function _emnapi_unwind (): never {
+  throw 'unwind'
+}
+
+/**
+ * @__sig d
+ */
+export function _emnapi_get_now (): double {
+  return performance.timeOrigin + performance.now()
 }
 
 export function $emnapiSetValueI64 (result: Pointer<int64_t>, numberValue: number): void {

--- a/packages/emnapi/src/wasi_wait.c
+++ b/packages/emnapi/src/wasi_wait.c
@@ -6,6 +6,17 @@
 #include <stdio.h>
 #include "emnapi_internal.h"
 
+struct __pthread {
+  unsigned char _[32];
+  volatile int cancel;
+  volatile unsigned char canceldisable, cancelasync;
+	unsigned char tsd_used:1;
+	unsigned char dlerror_flag:1;
+  unsigned char __[68];
+};
+
+#define INFINITY __builtin_inff()
+
 int __wasilibc_futex_wait_atomic_wait(volatile void *addr, int op, int val, int64_t max_wait_ns);
 
 static _Atomic pthread_t crashed_thread_id = NULL;
@@ -22,36 +33,14 @@ void _emnapi_yield() {
   }
 }
 
-int _emnapi_wait(int is_runtime_thread, volatile void *addr, int op, int val, double max_wait_ms) {
-  if (is_runtime_thread) {
-    _emnapi_yield();
-  }
-
-  int64_t max_wait_ns = -1;
-  if (max_wait_ms != __builtin_inff()) {
-    max_wait_ns = (int64_t)(max_wait_ms*1000*1000);
-  }
-
-  // https://github.com/WebAssembly/wasi-libc/blob/3f7eb4c7d6ede4dde3c4bffa6ed14e8d656fe93f/libc-top-half/musl/src/thread/wasm32/__wasilibc_busywait.c#L42
-  if (!_emnapi_is_main_browser_thread()) {
-    return __wasilibc_futex_wait_atomic_wait(addr, op, val, max_wait_ns);
-  }
-
-  struct timespec start;
-  int r = clock_gettime(CLOCK_REALTIME, &start);
-
-  if (r) return r;
+static int _emnapi_wait_main_browser_thread(int is_runtime_thread, volatile void *addr, int op, int val, double max_wait_ms) {
+  double now = _emnapi_get_now();
+  double end = now + max_wait_ms;
 
   while (1) {
-    if (max_wait_ns >= 0) {
-      struct timespec now;
-      r = clock_gettime(CLOCK_REALTIME, &now);
-      if (r) return r;
-
-      int64_t elapsed_ns = (now.tv_sec - start.tv_sec) * 1000000000 + now.tv_nsec - start.tv_nsec;
-      if (elapsed_ns >= max_wait_ns) {
-        return -ETIMEDOUT;
-      }
+    now = _emnapi_get_now();
+    if (now >= end) {
+      return -ETIMEDOUT;
     }
 
     if (is_runtime_thread) {
@@ -66,15 +55,39 @@ int _emnapi_wait(int is_runtime_thread, volatile void *addr, int op, int val, do
   return 0;
 }
 
+int _emnapi_wait(int is_runtime_thread, volatile void *addr, int op, int val, double max_wait_ms) {
+  if (is_runtime_thread) {
+    _emnapi_yield();
+  }
+
+  // https://github.com/WebAssembly/wasi-libc/blob/3f7eb4c7d6ede4dde3c4bffa6ed14e8d656fe93f/libc-top-half/musl/src/thread/wasm32/__wasilibc_busywait.c#L42
+  if (!_emnapi_is_main_browser_thread()) {
+    int64_t max_wait_ns = -1;
+    if (max_wait_ms != INFINITY) {
+      max_wait_ns = (int64_t)(max_wait_ms*1000*1000);
+    }
+    return __wasilibc_futex_wait_atomic_wait(addr, op, val, max_wait_ns);
+  }
+
+  return _emnapi_wait_main_browser_thread(is_runtime_thread, addr, op, val, max_wait_ms);
+}
+
 int __wasilibc_futex_wait_maybe_busy(volatile void *addr, int op, int val, int64_t max_wait_ns) {
+  // https://github.com/emscripten-core/emscripten/blob/89ce854a99238d04116a3d9b5afe241eec90c6c3/system/lib/libc/musl/src/thread/__timedwait.c#L60
   int r = 0;
-  double msecsToSleep = max_wait_ns >= 0 ? (max_wait_ns / 1000000.0) : __builtin_inff();
+  double msecsToSleep = max_wait_ns >= 0 ? (max_wait_ns / 1000000.0) : INFINITY;
   int is_runtime_thread = _emnapi_is_main_runtime_thread();
 	double max_ms_slice_to_sleep = is_runtime_thread ? 1 : 100;
 
-  if (is_runtime_thread) {
+  if (is_runtime_thread ||
+	    pthread_self()->canceldisable != PTHREAD_CANCEL_DISABLE ||
+	    pthread_self()->cancelasync) {
     double sleepUntilTime = _emnapi_get_now() + msecsToSleep;
 		do {
+      if (pthread_self()->cancel) {
+				pthread_testcancel();
+				return ECANCELED;
+			}
 			msecsToSleep = sleepUntilTime - _emnapi_get_now();
 			if (msecsToSleep <= 0) {
 				r = ETIMEDOUT;

--- a/packages/emnapi/src/wasi_wait.c
+++ b/packages/emnapi/src/wasi_wait.c
@@ -1,0 +1,90 @@
+#if defined(__wasi__)
+
+#include <time.h>
+#include <errno.h>
+#include <pthread.h>
+#include <stdio.h>
+#include "emnapi_internal.h"
+
+int __wasilibc_futex_wait_atomic_wait(volatile void *addr, int op, int val, int64_t max_wait_ns);
+
+static _Atomic pthread_t crashed_thread_id = NULL;
+
+__attribute__((visibility("default")))
+void emnapi_thread_crashed() {
+  crashed_thread_id = pthread_self();
+}
+
+void _emnapi_yield() {
+  if (crashed_thread_id) {
+    _emnapi_runtime_keepalive_push();
+    _emnapi_unwind();
+  }
+}
+
+int _emnapi_wait(int is_runtime_thread, volatile void *addr, int op, int val, int64_t max_wait_ns) {
+  if (is_runtime_thread) {
+    _emnapi_yield();
+  }
+
+  // https://github.com/WebAssembly/wasi-libc/blob/3f7eb4c7d6ede4dde3c4bffa6ed14e8d656fe93f/libc-top-half/musl/src/thread/wasm32/__wasilibc_busywait.c#L42
+  if (!_emnapi_is_main_browser_thread()) {
+    return __wasilibc_futex_wait_atomic_wait(addr, op, val, max_wait_ns);
+  }
+
+  struct timespec start;
+  int r = clock_gettime(CLOCK_REALTIME, &start);
+
+  if (r) return r;
+
+  while (1) {
+    if (max_wait_ns >= 0) {
+      struct timespec now;
+      r = clock_gettime(CLOCK_REALTIME, &now);
+      if (r) return r;
+
+      int64_t elapsed_ns = (now.tv_sec - start.tv_sec) * 1000000000 + now.tv_nsec - start.tv_nsec;
+      if (elapsed_ns >= max_wait_ns) {
+        return -ETIMEDOUT;
+      }
+    }
+
+    if (is_runtime_thread) {
+      _emnapi_yield();
+    }
+
+    if (__c11_atomic_load((_Atomic int *)addr, __ATOMIC_SEQ_CST) != val) {
+      break;
+    }
+  }
+
+  return 0;
+}
+
+int __wasilibc_futex_wait_maybe_busy(volatile void *addr, int op, int val, int64_t max_wait_ns) {
+  printf("Futex wait called with addr=%p, op=%d, val=%d, max_wait_ns=%lld\n", addr, op, val, max_wait_ns);
+
+  int r = 0;
+  double msecsToSleep = max_wait_ns >= 0 ? (max_wait_ns / 1000000.0) : __builtin_inff();
+  int is_runtime_thread = _emnapi_is_main_runtime_thread();
+	double max_ms_slice_to_sleep = is_runtime_thread ? 1 : 100;
+
+  if (is_runtime_thread) {
+    double sleepUntilTime = _emnapi_get_now() + msecsToSleep;
+		do {
+			msecsToSleep = sleepUntilTime - _emnapi_get_now();
+			if (msecsToSleep <= 0) {
+				r = ETIMEDOUT;
+				break;
+			}
+			if (msecsToSleep > max_ms_slice_to_sleep)
+				msecsToSleep = max_ms_slice_to_sleep;
+			r = -_emnapi_wait(is_runtime_thread, (void*)addr, op, val, msecsToSleep);
+		} while (r == ETIMEDOUT);
+  } else {
+    r = -_emnapi_wait(is_runtime_thread, (void*)addr, op, val, msecsToSleep);
+  }
+  return r;
+}
+
+#endif

--- a/packages/emnapi/src/wasi_wait.c
+++ b/packages/emnapi/src/wasi_wait.c
@@ -22,9 +22,14 @@ void _emnapi_yield() {
   }
 }
 
-int _emnapi_wait(int is_runtime_thread, volatile void *addr, int op, int val, int64_t max_wait_ns) {
+int _emnapi_wait(int is_runtime_thread, volatile void *addr, int op, int val, double max_wait_ms) {
   if (is_runtime_thread) {
     _emnapi_yield();
+  }
+
+  int64_t max_wait_ns = -1;
+  if (max_wait_ms != __builtin_inff()) {
+    max_wait_ns = (int64_t)(max_wait_ms*1000*1000);
   }
 
   // https://github.com/WebAssembly/wasi-libc/blob/3f7eb4c7d6ede4dde3c4bffa6ed14e8d656fe93f/libc-top-half/musl/src/thread/wasm32/__wasilibc_busywait.c#L42

--- a/packages/emnapi/src/wasi_wait.c
+++ b/packages/emnapi/src/wasi_wait.c
@@ -67,8 +67,6 @@ int _emnapi_wait(int is_runtime_thread, volatile void *addr, int op, int val, do
 }
 
 int __wasilibc_futex_wait_maybe_busy(volatile void *addr, int op, int val, int64_t max_wait_ns) {
-  printf("Futex wait called with addr=%p, op=%d, val=%d, max_wait_ns=%lld\n", addr, op, val, max_wait_ns);
-
   int r = 0;
   double msecsToSleep = max_wait_ns >= 0 ? (max_wait_ns / 1000000.0) : __builtin_inff();
   int is_runtime_thread = _emnapi_is_main_runtime_thread();

--- a/packages/runtime/src/Context.ts
+++ b/packages/runtime/src/Context.ts
@@ -33,6 +33,10 @@ const withScope = (envObject: Env, thiz: any, args: any[], data: number | bigint
   callbackInfo.fn = getFunction
   try {
     return wrapper(envObject, callback)
+  } catch (e) {
+    if (e !== 'unwind') {
+      throw e
+    }
   } finally {
     envObject.ctx.closeScope(envObject, scope)
   }

--- a/packages/runtime/src/FunctionTemplate.ts
+++ b/packages/runtime/src/FunctionTemplate.ts
@@ -86,9 +86,12 @@ export class FunctionTemplate extends Template {
         const ret = callback(ctx.getCurrentScope()!.id, v8FunctionCallback)
         returnValue = ret ? ctx.jsValueFromNapiValue(ret) : undefined
       } catch (err) {
-        ctx.throwException(err)
+        if (err !== 'unwind') {
+          ctx.throwException(err)
+        }
+      } finally {
+        ctx.closeScope(scope)
       }
-      ctx.closeScope(scope)
       if (ctx.hasPendingException()) {
         if (TryCatch.top) {
           TryCatch.top.setError(ctx.getAndClearLastException())

--- a/packages/test/CMakeLists.txt
+++ b/packages/test/CMakeLists.txt
@@ -105,7 +105,7 @@ elseif(IS_WASI_THREADS)
   set(COMMON_LINK_OPTIONS
     # "-v"
     "-mexec-model=reactor"
-    "-Wl,-zstack-size=1048576,--initial-memory=16777216,--max-memory=2147483648,--import-memory,--export-dynamic,--export=malloc,--export=free,--export=pthread_self,--import-undefined,--export-table"
+    "-Wl,-zstack-size=1048576,--initial-memory=16777216,--max-memory=2147483648,--import-memory,--export-dynamic,--export=malloc,--export=free,--export=emnapi_thread_crashed,--import-undefined,--export-table"
   )
   set(COMMON_EXPORTS_NAPI
     "-Wl,--export=napi_register_wasm_v1,--export-if-defined=node_api_module_get_api_version_v1"
@@ -414,6 +414,9 @@ function(add_test_v8 NAME SOURCE_LIST PTHREAD)
         endif()
       else()
         target_link_libraries(${NAME} PRIVATE "v8-mt")
+        if(NOT IS_EMSCRIPTEN)
+          target_link_libraries(${NAME} PRIVATE "emnapi-basic-mt")
+        endif()
         target_compile_options(${NAME} PRIVATE "-pthread")
         target_link_options(${NAME} PRIVATE "-pthread")
       endif()
@@ -422,6 +425,9 @@ function(add_test_v8 NAME SOURCE_LIST PTHREAD)
       endif()
     else()
       target_link_libraries(${NAME} PRIVATE "v8")
+      if(NOT IS_EMSCRIPTEN)
+        target_link_libraries(${NAME} PRIVATE "emnapi-basic")
+      endif()
     endif()
   endif()
   target_include_directories(${NAME} PRIVATE "../../node_modules/nan")

--- a/packages/test/CMakeLists.txt
+++ b/packages/test/CMakeLists.txt
@@ -105,7 +105,7 @@ elseif(IS_WASI_THREADS)
   set(COMMON_LINK_OPTIONS
     # "-v"
     "-mexec-model=reactor"
-    "-Wl,-zstack-size=1048576,--initial-memory=16777216,--max-memory=2147483648,--import-memory,--export-dynamic,--export=malloc,--export=free,--import-undefined,--export-table"
+    "-Wl,-zstack-size=1048576,--initial-memory=16777216,--max-memory=2147483648,--import-memory,--export-dynamic,--export=malloc,--export=free,--export=pthread_self,--import-undefined,--export-table"
   )
   set(COMMON_EXPORTS_NAPI
     "-Wl,--export=napi_register_wasm_v1,--export-if-defined=node_api_module_get_api_version_v1"

--- a/packages/test/async/main.js
+++ b/packages/test/async/main.js
@@ -28,7 +28,7 @@ module.exports = async function main (loadPromise, __filename) {
   const p = child_process.spawnSync(
     process.execPath, [
       ...(process.env.EMNAPI_TEST_WASI ? ['--experimental-wasi-unstable-preview1'] : []),
-      ...(process.env.MEMORY64 ? ['--experimental-wasm-memory64'] : []),
+      // ...(process.env.MEMORY64 ? ['--experimental-wasm-memory64'] : []),
       __filename,
       'child'
     ])

--- a/packages/test/cleanup_hook/cleanup_hook.test.js
+++ b/packages/test/cleanup_hook/cleanup_hook.test.js
@@ -12,7 +12,7 @@ if (process.argv[2] === 'child') {
       child_process.spawnSync(process.execPath, [
         '--expose-gc',
         ...(process.env.EMNAPI_TEST_WASI ? ['--experimental-wasi-unstable-preview1'] : []),
-        ...(process.env.MEMORY64 ? ['--experimental-wasm-memory64'] : []),
+        // ...(process.env.MEMORY64 ? ['--experimental-wasm-memory64'] : []),
         __filename,
         'child'
       ])

--- a/packages/test/exception/exception.finalizer.test.js
+++ b/packages/test/exception/exception.finalizer.test.js
@@ -28,7 +28,7 @@ async function main () {
   const child = spawnSync(process.execPath, [
     '--expose-gc',
     ...(process.env.EMNAPI_TEST_WASI ? ['--experimental-wasi-unstable-preview1'] : []),
-    ...(process.env.MEMORY64 ? ['--experimental-wasm-memory64'] : []),
+    // ...(process.env.MEMORY64 ? ['--experimental-wasm-memory64'] : []),
     __filename,
     'child'
   ])

--- a/packages/test/finalizer/finalizer_fatal.test.js
+++ b/packages/test/finalizer/finalizer_fatal.test.js
@@ -29,7 +29,7 @@ module.exports = load('finalizer').then(async test_finalizer => {
   const child = spawnSync(process.execPath, [
     '--expose-gc',
     ...(process.env.EMNAPI_TEST_WASI ? ['--experimental-wasi-unstable-preview1'] : []),
-    ...(process.env.MEMORY64 ? ['--experimental-wasm-memory64'] : []),
+    // ...(process.env.MEMORY64 ? ['--experimental-wasm-memory64'] : []),
     __filename,
     'child'
   ])

--- a/packages/test/node-addon-api/error.test.js
+++ b/packages/test/node-addon-api/error.test.js
@@ -72,7 +72,7 @@ async function test (bindingPath) {
     process.execPath, [
       '--expose-gc',
       ...(process.env.EMNAPI_TEST_WASI ? ['--experimental-wasi-unstable-preview1'] : []),
-      ...(process.env.MEMORY64 ? ['--experimental-wasm-memory64'] : []),
+      // ...(process.env.MEMORY64 ? ['--experimental-wasm-memory64'] : []),
       __filename,
       'fatal',
       bindingPath

--- a/packages/test/script/test.js
+++ b/packages/test/script/test.js
@@ -76,7 +76,7 @@ function test (f) {
     '--expose-gc',
     ...additionalFlags,
     ...(process.env.EMNAPI_TEST_WASI ? ['--experimental-wasi-unstable-preview1'] : []),
-    ...(process.env.MEMORY64 ? ['--experimental-wasm-memory64'] : []),
+    // ...(process.env.MEMORY64 ? ['--experimental-wasm-memory64'] : []),
     './script/test-entry.js',
     f
   ], { cwd, env: process.env, stdio: 'inherit' })

--- a/packages/test/trap_in_thread/binding.c
+++ b/packages/test/trap_in_thread/binding.c
@@ -91,11 +91,19 @@ static napi_value AbortInThread(napi_env env, napi_callback_info info) {
   return NULL;
 }
 
+static napi_value Join(napi_env env, napi_callback_info info) {
+  pthread_t uv_threads;
+  pthread_create(&uv_threads, NULL, ThreadAbort, NULL);
+  pthread_join(uv_threads, NULL);
+  return NULL;
+}
+
 static napi_value Init(napi_env env, napi_value exports) {
   napi_property_descriptor descriptors[] = {
     DECLARE_NODE_API_PROPERTY("abort", Abort),
     DECLARE_NODE_API_PROPERTY("releaseInThread", ReleaseInThread),
     DECLARE_NODE_API_PROPERTY("abortInThread", AbortInThread),
+    DECLARE_NODE_API_PROPERTY("join", Join),
   };
 
   NODE_API_CALL(env, napi_define_properties(

--- a/packages/test/trap_in_thread/trap_in_thread-wasi.html
+++ b/packages/test/trap_in_thread/trap_in_thread-wasi.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>trap_in_thread-wasi</title>
+</head>
+<body>
+  <script src="trap_in_thread-wasi.js" type="module"></script>
+</body>
+</html>

--- a/packages/test/trap_in_thread/trap_in_thread-wasi.js
+++ b/packages/test/trap_in_thread/trap_in_thread-wasi.js
@@ -1,0 +1,45 @@
+/* eslint-disable no-undef */
+/* eslint-disable camelcase */
+
+import * as wasmUtil from '../../../node_modules/@tybys/wasm-util/dist/wasm-util.esm.js'
+import * as emnapiCore from '../../../node_modules/@emnapi/core/dist/emnapi-core.js'
+import * as emnapi from '../../runtime/dist/emnapi.js'
+
+(async function main () {
+  const init = function () {
+    const { WASI } = wasmUtil
+    const { createNapiModule, loadNapiModule } = emnapiCore
+    const { getDefaultContext } = emnapi
+    const wasi = new WASI()
+    const napiModule = createNapiModule({
+      context: getDefaultContext(),
+      reuseWorker: {
+        size: 1,
+        strict: true
+      },
+      onCreateWorker () {
+        return new Worker('../worker.mjs', { type: 'module' })
+      }
+    })
+    const wasmMemory = new WebAssembly.Memory({
+      initial: 16777216 / 65536,
+      maximum: 2147483648 / 65536,
+      shared: true
+    })
+
+    const p = new Promise((resolve, reject) => {
+      loadNapiModule(napiModule, '../.build/wasm32-wasi-threads/Debug/trap_in_thread.wasm', {
+        wasi,
+        overwriteImports (importObject) {
+          importObject.env.memory = wasmMemory
+        }
+      }).then(() => {
+        resolve(napiModule.exports)
+      }).catch(reject)
+    })
+    p.Module = napiModule
+    return p
+  }
+  const binding = await init()
+  binding.join()
+})()

--- a/packages/test/trap_in_thread/trap_in_thread.test.js
+++ b/packages/test/trap_in_thread/trap_in_thread.test.js
@@ -41,6 +41,7 @@ async function main () {
   await test('abort', 'SIGABRT')
   await test('releaseInThread', null)
   await test('abortInThread','SIGABRT')
+  await test('join','SIGABRT')
 }
 
 module.exports = main()

--- a/packages/test/trap_in_thread/trap_in_thread.test.js
+++ b/packages/test/trap_in_thread/trap_in_thread.test.js
@@ -15,7 +15,7 @@ async function main () {
     const child = spawn(process.execPath, [
       '--expose-gc',
       ...(process.env.EMNAPI_TEST_WASI ? ['--experimental-wasi-unstable-preview1'] : []),
-      ...(process.env.MEMORY64 ? ['--experimental-wasm-memory64'] : []),
+      // ...(process.env.MEMORY64 ? ['--experimental-wasm-memory64'] : []),
       __filename,
       'child', f
     ], { stdio: 'inherit' })

--- a/packages/test/util.js
+++ b/packages/test/util.js
@@ -58,7 +58,8 @@ function loadPath (request, options) {
               },
               waitThreadStart: 1000,
               onCreateWorker () {
-                return new Worker(join(__dirname, './worker.js'), {
+                return new Worker(join(__dirname, './worker.mjs'), {
+                  type: 'module',
                   env: process.env,
                   execArgv: ['--experimental-wasi-unstable-preview1']
                 })
@@ -97,7 +98,8 @@ function loadPath (request, options) {
         context,
         asyncWorkPoolSize: RUNTIME_UV_THREADPOOL_SIZE,
         onCreateWorker () {
-          return new Worker(join(__dirname, './worker.js'), {
+          return new Worker(join(__dirname, './worker.mjs'), {
+            type: 'module',
             env: process.env
           })
         },

--- a/packages/wasi-threads/src/command.ts
+++ b/packages/wasi-threads/src/command.ts
@@ -1,28 +1,35 @@
+/** @public */
 export interface LoadPayload {
   wasmModule: WebAssembly.Module
   wasmMemory: WebAssembly.Memory
   sab?: Int32Array
 }
 
+/** @public */
 export interface LoadedPayload {}
 
+/** @public */
 export interface StartPayload {
   tid: number
   arg: number
   sab?: Int32Array
 }
 
+/** @public */
 export interface CleanupThreadPayload {
   tid: number
 }
 
+/** @public */
 export interface TerminateAllThreadsPayload {}
 
+/** @public */
 export interface SpawnThreadPayload {
   startArg: number
   errorOrTid: number
 }
 
+/** @public */
 export interface CommandPayloadMap {
   load: LoadPayload
   loaded: LoadedPayload
@@ -32,13 +39,16 @@ export interface CommandPayloadMap {
   'spawn-thread': SpawnThreadPayload
 }
 
-type CommandType = keyof CommandPayloadMap
+/** @public */
+export type CommandType = keyof CommandPayloadMap
 
+/** @public */
 export interface CommandInfo<T extends CommandType> {
-  type: CommandType
+  type: T
   payload: CommandPayloadMap[T]
 }
 
+/** @public */
 export interface MessageEventData<T extends CommandType> {
   __emnapi__: CommandInfo<T>
 }

--- a/packages/wasi-threads/src/index.ts
+++ b/packages/wasi-threads/src/index.ts
@@ -25,10 +25,21 @@ export type {
 export { WASIThreads } from './wasi-threads'
 
 export { ThreadMessageHandler } from './worker'
-export type { ThreadMessageHandlerOptions } from './worker'
+export type { ThreadMessageHandlerOptions, WorkerMessageType } from './worker'
 
 export { createInstanceProxy } from './proxy'
 
 export { isTrapError, isSharedArrayBuffer } from './util'
 
-export type { LoadPayload } from './command'
+export type {
+  LoadPayload,
+  LoadedPayload,
+  StartPayload,
+  CleanupThreadPayload,
+  TerminateAllThreadsPayload,
+  SpawnThreadPayload,
+  CommandPayloadMap,
+  CommandType,
+  CommandInfo,
+  MessageEventData
+} from './command'


### PR DESCRIPTION
fix #159 

- Requires https://github.com/WebAssembly/wasi-libc/pull/562 (wasi-sdk 26+)
- Requires WASI users to pass `--export=emnapi_thread_crashed` to wasm-ld