### PR TITLE
build!: migrate to pure esm

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,27 +3,13 @@
   "version": "1.4.0",
   "description": "emnapi core",
   "type": "module",
-  "main": "./dist/emnapi-core.cjs",
+  "main": "./dist/emnapi-core.js",
   "module": "./dist/emnapi-core.js",
-  "types": "./dist/emnapi-core.d.cts",
+  "types": "./dist/emnapi-core.d.ts",
   "sideEffects": false,
   "exports": {
-    ".": {
-      "types": {
-        "module": "./dist/emnapi-core.d.ts",
-        "module-sync": "./dist/emnapi-core.d.ts",
-        "import": "./dist/emnapi-core.d.cts",
-        "require": "./dist/emnapi-core.d.cts",
-        "default": "./dist/emnapi-core.d.cts"
-      },
-      "module": "./dist/emnapi-core.js",
-      "module-sync": "./dist/emnapi-core.js",
-      "default": "./dist/emnapi-core.cjs"
-    },
-    "./plugins/v8": {
-      "types": "./dist/plugins/v8.d.ts",
-      "default": "./dist/plugins/v8.js"
-    },
+    ".": "./dist/emnapi-core.js",
+    "./plugins/v8": "./dist/plugins/v8.js",
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -15,9 +15,6 @@ export default [
     outputFile: 'plugins/v8',
     dtsEntry: 'dist/types/emnapi/v8.d.ts',
     input: join(import.meta.dirname, 'src/emnapi/v8.js'),
-    cjs: false,
-    browser: false,
-    umd: true,
     compilerOptions: {
       declaration: false,
       declarationMap: false,

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -3,23 +3,12 @@
   "version": "1.4.0",
   "description": "emnapi runtime",
   "type": "module",
-  "main": "./dist/emnapi.cjs",
+  "main": "./dist/emnapi.js",
   "module": "./dist/emnapi.js",
-  "types": "./dist/emnapi.d.cts",
+  "types": "./dist/emnapi.d.ts",
   "sideEffects": false,
   "exports": {
-    ".": {
-      "types": {
-        "module": "./dist/emnapi.d.ts",
-        "module-sync": "./dist/emnapi.d.ts",
-        "import": "./dist/emnapi.d.cts",
-        "require": "./dist/emnapi.d.cts",
-        "default": "./dist/emnapi.d.cts"
-      },
-      "module": "./dist/emnapi.js",
-      "module-sync": "./dist/emnapi.js",
-      "default": "./dist/emnapi.cjs"
-    },
+    ".": "./dist/emnapi.js",
     "./package.json": "./package.json"
   },
   "dependencies": {

--- a/packages/shared/src/rollup.ts
+++ b/packages/shared/src/rollup.ts
@@ -190,14 +190,14 @@ export function makeConfig (options: MakeConfigOptions): RollupOptions {
       format: 'umd',
       name: outputName,
       exports: outputExports,
-      sourcemap
+      // sourcemap
     } satisfies RollupOptions['output'],
     iife: {
       file: `${outputDir}/${outputFile}.iife${minify ? '.min' : ''}.cjs`,
       format: 'iife',
       name: outputName,
       exports: outputExports,
-      sourcemap
+      // sourcemap
     } satisfies RollupOptions['output']
   }
 
@@ -234,7 +234,7 @@ export function makeConfig (options: MakeConfigOptions): RollupOptions {
 }
 
 export function defineConfig (options: Options): RollupOptions[] {
-  const { browser = true, cjs = true, umd = true, ...restOptions } = options
+  const { browser = false, cjs = false, umd = false, ...restOptions } = options
   return ([
     ['esm', false],
     ...(cjs ? [['cjs', false]] as const : []),

--- a/packages/wasi-threads/package.json
+++ b/packages/wasi-threads/package.json
@@ -3,23 +3,12 @@
   "version": "1.0.4",
   "description": "WASI threads proposal implementation in JavaScript",
   "type": "module",
-  "main": "./dist/wasi-threads.cjs",
+  "main": "./dist/wasi-threads.js",
   "module": "./dist/wasi-threads.js",
-  "types": "./dist/wasi-threads.d.cts",
+  "types": "./dist/wasi-threads.d.ts",
   "sideEffects": false,
   "exports": {
-    ".": {
-      "types": {
-        "module": "./dist/wasi-threads.d.ts",
-        "module-sync": "./dist/wasi-threads.d.ts",
-        "import": "./dist/wasi-threads.d.cts",
-        "require": "./dist/wasi-threads.d.cts",
-        "default": "./dist/wasi-threads.d.cts"
-      },
-      "module": "./dist/wasi-threads.js",
-      "module-sync": "./dist/wasi-threads.js",
-      "default": "./dist/wasi-threads.cjs"
-    },
+    ".": "./dist/wasi-threads.js",
     "./package.json": "./package.json"
   },
   "dependencies": {


### PR DESCRIPTION
Ref: #137 

Now we are ESM only, no longer provide CJS or UMD 