### PR TITLE
refactor: make real napi_env struct definition in C

### DIFF
--- a/packages/emnapi/include/node/js_native_api_types.h
+++ b/packages/emnapi/include/node/js_native_api_types.h
@@ -237,4 +237,14 @@ typedef struct {
 } napi_type_tag;
 #endif  // NAPI_VERSION >= 8
 
+#ifndef EMNAPI_UNMODIFIED_UPSTREAM
+struct napi_env__ {
+  void* reserved;
+  uint64_t sentinel;  // Should be NODE_API_VT_SENTINEL
+  const struct node_api_js_vtable* js_vtable;
+  const struct node_api_module_vtable* module_vtable;
+  napi_extended_error_info last_error;
+};
+#endif
+
 #endif  // SRC_JS_NATIVE_API_TYPES_H_

--- a/packages/emnapi/script/build.js
+++ b/packages/emnapi/script/build.js
@@ -315,7 +315,7 @@ async function build () {
       coreTsconfigPath,
       path.join(__dirname, '../src/core/async-work.ts'),
       path.join(outputDir, 'async-work.js'),
-      ['emnapiCtx', 'emnapiNodeBinding', 'emnapiAsyncWorkPoolSize'],
+      ['emnapiCtx', 'emnapiEnv', 'emnapiNodeBinding', 'emnapiAsyncWorkPoolSize'],
       ['napi']
     ),
     buildNonEmscriptenPlugin(
@@ -324,6 +324,7 @@ async function build () {
       path.join(outputDir, 'threadsafe-function.js'),
       [
         'emnapiCtx',
+        'emnapiEnv',
         'emnapiNodeBinding',
         '_emnapi_node_emit_async_destroy: __emnapi_node_emit_async_destroy',
         '_emnapi_node_emit_async_init: __emnapi_node_emit_async_init',

--- a/packages/emnapi/src/async-work.ts
+++ b/packages/emnapi/src/async-work.ts
@@ -1,6 +1,7 @@
 import { makeDynCall } from 'emscripten:parse-tools'
 
 declare var emnapiCtx: Context
+declare var emnapiEnv: Env
 declare var emnapiNodeBinding: NodeBinding | undefined
 declare var emnapiAsyncWorkPoolSize: number
 
@@ -25,6 +26,7 @@ export interface AsyncWork {
 
 /**
  * @__deps $emnapiCtx
+ * @__deps $emnapiEnv
  * @__deps $emnapiNodeBinding
  * @__deps $emnapiAsyncWorkPoolSize
  * @__postset
@@ -97,7 +99,7 @@ export var emnapiAWST = {
     const data = work.data
     const callback = (): void => {
       if (!complete) return
-      const envObject = emnapiCtx.getEnv(env)!
+      const envObject = emnapiEnv
       const scope = emnapiCtx.openScope(envObject)
       try {
         (envObject as NodeEnv).callbackIntoModule(true, () => {

--- a/packages/emnapi/src/core/async-work.ts
+++ b/packages/emnapi/src/core/async-work.ts
@@ -9,6 +9,7 @@ import { $CHECK_ENV_NOT_IN_GC, $CHECK_ARG, $CHECK_ENV } from '../macro'
 
 declare var emnapiPluginCtx: any
 declare var emnapiCtx: Context
+declare var emnapiEnv: Env
 declare var emnapiNodeBinding: NodeBinding | undefined
 
 const {
@@ -237,7 +238,7 @@ var emnapiAWMT = {
     const complete = emnapiAWMT.getComplete(work)
     const env = emnapiAWMT.getEnv(work)
     const data = emnapiAWMT.getData(work)
-    const envObject = emnapiCtx.getEnv(env)!
+    const envObject = emnapiEnv
     const scope = emnapiCtx.openScope(envObject)
     const callback = (): void => {
       if (!complete) return
@@ -357,7 +358,7 @@ export var napi_delete_async_work = singleThreadAsyncWork
 export var napi_queue_async_work = singleThreadAsyncWork
   ? function (env: napi_env, work: number): napi_status {
     $CHECK_ENV!(env)
-    const envObject = emnapiCtx.getEnv(env)!
+    const envObject = emnapiEnv
     $CHECK_ARG!(envObject, work)
 
     emnapiAWST.queue(work)
@@ -365,7 +366,7 @@ export var napi_queue_async_work = singleThreadAsyncWork
   }
   : function (env: napi_env, work: number): napi_status {
     $CHECK_ENV!(env)
-    const envObject = emnapiCtx.getEnv(env)!
+    const envObject = emnapiEnv
     $CHECK_ARG!(envObject, work)
 
     emnapiAWMT.scheduleWork(work)
@@ -376,7 +377,7 @@ export var napi_queue_async_work = singleThreadAsyncWork
 export var napi_cancel_async_work = singleThreadAsyncWork
   ? function (env: napi_env, work: number): napi_status {
     $CHECK_ENV!(env)
-    const envObject = emnapiCtx.getEnv(env)!
+    const envObject = emnapiEnv
     $CHECK_ARG!(envObject, work)
 
     const status = emnapiAWST.cancel(work)
@@ -385,7 +386,7 @@ export var napi_cancel_async_work = singleThreadAsyncWork
   }
   : function (env: napi_env, work: number): napi_status {
     $CHECK_ENV!(env)
-    const envObject = emnapiCtx.getEnv(env)!
+    const envObject = emnapiEnv
     $CHECK_ARG!(envObject, work)
 
     const status = emnapiAWMT.cancelWork(work)

--- a/packages/emnapi/src/core/memory.ts
+++ b/packages/emnapi/src/core/memory.ts
@@ -1,4 +1,4 @@
-import { emnapiCtx } from 'emnapi:shared'
+import { emnapiCtx, emnapiEnv } from 'emnapi:shared'
 import { wasmMemory } from 'emscripten:runtime'
 import { from64, makeSetValue } from 'emscripten:parse-tools'
 import { $CHECK_ENV, $CHECK_ARG } from '../macro'
@@ -11,7 +11,7 @@ export function napi_adjust_external_memory (
   adjusted_value: number
 ): napi_status {
   $CHECK_ENV!(env)
-  const envObject = emnapiCtx.getEnv(env)!
+  const envObject = emnapiEnv
   $CHECK_ARG!(envObject, adjusted_value)
 
   const change_in_bytes_number = Number(change_in_bytes)

--- a/packages/emnapi/src/emnapi.ts
+++ b/packages/emnapi/src/emnapi.ts
@@ -1,4 +1,4 @@
-import { emnapiCtx, emnapiNodeBinding } from 'emnapi:shared'
+import { emnapiCtx, emnapiEnv, emnapiNodeBinding } from 'emnapi:shared'
 import { wasmMemory } from 'emscripten:runtime'
 import { from64, makeSetValue, makeGetValue } from 'emscripten:parse-tools'
 import { type MemoryViewDescriptor, type ArrayBufferPointer, emnapiExternalMemory } from './memory'
@@ -304,7 +304,7 @@ export function emnapi_get_memory_address (env: napi_env, arraybuffer_or_view: n
  */
 export function emnapi_get_runtime_version (env: napi_env, version: number): napi_status {
   $CHECK_ENV!(env)
-  const envObject = emnapiCtx.getEnv(env)!
+  const envObject = emnapiEnv
   $CHECK_ARG!(envObject, version)
 
   let runtimeVersion: string

--- a/packages/emnapi/src/emscripten/async-work.ts
+++ b/packages/emnapi/src/emscripten/async-work.ts
@@ -3,9 +3,11 @@ import { emnapiAWST } from '../async-work'
 import { $CHECK_ARG, $CHECK_ENV, $CHECK_ENV_NOT_IN_GC } from '../macro'
 
 declare var emnapiCtx: Context
+declare var emnapiEnv: Env
 
 /**
  * @__deps $emnapiCtx
+ * @__deps $emnapiEnv
  * @__sig ippppppp
  */
 export function napi_create_async_work (env: napi_env, resource: napi_value, resource_name: napi_value, execute: number, complete: number, data: number, result: number): napi_status {
@@ -47,7 +49,7 @@ export function napi_delete_async_work (env: napi_env, work: number): napi_statu
  */
 export function napi_queue_async_work (env: napi_env, work: number): napi_status {
   $CHECK_ENV!(env)
-  const envObject = emnapiCtx.getEnv(env)!
+  const envObject = emnapiEnv
   $CHECK_ARG!(envObject, work)
 
   emnapiAWST.queue(work)
@@ -60,7 +62,7 @@ export function napi_queue_async_work (env: napi_env, work: number): napi_status
  */
 export function napi_cancel_async_work (env: napi_env, work: number): napi_status {
   $CHECK_ENV!(env)
-  const envObject = emnapiCtx.getEnv(env)!
+  const envObject = emnapiEnv
   $CHECK_ARG!(envObject, work)
 
   const status = emnapiAWST.cancel(work)

--- a/packages/emnapi/src/emscripten/emnapi.ts
+++ b/packages/emnapi/src/emscripten/emnapi.ts
@@ -1,4 +1,4 @@
-import { emnapiCtx } from 'emnapi:shared'
+import { emnapiCtx, emnapiEnv } from 'emnapi:shared'
 import { Module } from 'emscripten:runtime'
 import { from64, makeSetValue } from 'emscripten:parse-tools'
 import { emnapiString } from '../string'

--- a/packages/emnapi/src/emscripten/index.ts
+++ b/packages/emnapi/src/emscripten/index.ts
@@ -1,6 +1,7 @@
 export {
   emnapiInit as $emnapiInit,
   emnapiCtx as $emnapiCtx,
+  emnapiEnv as $emnapiEnv,
   emnapiAsyncWorkPoolSize as $emnapiAsyncWorkPoolSize,
   emnapiNodeBinding as $emnapiNodeBinding,
   _emnapi_async_work_pool_size

--- a/packages/emnapi/src/emscripten/memory.ts
+++ b/packages/emnapi/src/emscripten/memory.ts
@@ -1,5 +1,5 @@
 import { wasmMemory } from 'emscripten:runtime'
-import { emnapiCtx } from 'emnapi:shared'
+import { emnapiCtx, emnapiEnv } from 'emnapi:shared'
 import { from64, makeSetValue } from 'emscripten:parse-tools'
 import { $emnapiSetValueI64 as emnapiSetValueI64 } from '../util'
 import { $CHECK_ENV } from '../macro'
@@ -18,7 +18,7 @@ export function napi_adjust_external_memory (
   adjusted_value: number
 ): napi_status {
   $CHECK_ENV!(env)
-  const envObject = emnapiCtx.getEnv(env)!
+  const envObject = emnapiEnv
 
   let change_in_bytes: number
 

--- a/packages/emnapi/src/env.ts
+++ b/packages/emnapi/src/env.ts
@@ -1,11 +1,11 @@
-import { emnapiCtx } from 'emnapi:shared'
+import { emnapiEnv } from 'emnapi:shared'
 import { from64, makeSetValue } from 'emscripten:parse-tools'
 import { $CHECK_ENV, $CHECK_ARG } from './macro'
 
 /** @__sig ipppp */
 export function napi_set_instance_data (env: napi_env, data: void_p, finalize_cb: napi_finalize, finalize_hint: void_p): napi_status {
   $CHECK_ENV!(env)
-  const envObject = emnapiCtx.getEnv(env)!
+  const envObject = emnapiEnv!
   from64('data')
   from64('finalize_cb')
   from64('finalize_hint')
@@ -16,7 +16,7 @@ export function napi_set_instance_data (env: napi_env, data: void_p, finalize_cb
 /** @__sig ipp */
 export function napi_get_instance_data (env: napi_env, data: void_pp): napi_status {
   $CHECK_ENV!(env)
-  const envObject = emnapiCtx.getEnv(env)!
+  const envObject = emnapiEnv!
   $CHECK_ARG!(envObject, data)
   from64('data')
 

--- a/packages/emnapi/src/error.ts
+++ b/packages/emnapi/src/error.ts
@@ -1,26 +1,8 @@
 import { abort } from 'emscripten:runtime'
-import { emnapiCtx, emnapiNodeBinding } from 'emnapi:shared'
+import { emnapiCtx, emnapiNodeBinding, emnapiEnv } from 'emnapi:shared'
 import { from64, makeSetValue } from 'emscripten:parse-tools'
 import { $PREAMBLE, $CHECK_ARG, $CHECK_ENV_NOT_IN_GC } from './macro'
 import { emnapiString } from './string'
-
-/** @__sig vpppp */
-export function _emnapi_get_last_error_info (env: napi_env, error_code: Pointer<napi_status>, engine_error_code: Pointer<uint32_t>, engine_reserved: void_pp): void {
-  from64('error_code')
-  from64('engine_error_code')
-  from64('engine_reserved')
-  const envObject = emnapiCtx.getEnv(env)!
-
-  const lastError = envObject.lastError
-  const errorCode = lastError.errorCode
-  const engineErrorCode = lastError.engineErrorCode >>> 0
-  let engineReserved = lastError.engineReserved
-  from64('engineReserved')
-
-  makeSetValue('error_code', 0, 'errorCode', 'i32')
-  makeSetValue('engine_error_code', 0, 'engineErrorCode', 'u32')
-  makeSetValue('engine_reserved', 0, 'engineReserved', '*')
-}
 
 /** @__sig ipp */
 export function napi_throw (env: napi_env, error: napi_value): napi_status {

--- a/packages/emnapi/src/function.ts
+++ b/packages/emnapi/src/function.ts
@@ -1,4 +1,4 @@
-import { emnapiCtx } from 'emnapi:shared'
+import { emnapiCtx, emnapiEnv } from 'emnapi:shared'
 import { from64, makeSetValue, makeGetValue, SIZE_TYPE, POINTER_SIZE } from 'emscripten:parse-tools'
 import { emnapiCreateFunction } from './internal'
 import { $PREAMBLE, $CHECK_ARG, $CHECK_ENV, $CHECK_ENV_NOT_IN_GC, $GET_RETURN_STATUS } from './macro'
@@ -27,7 +27,7 @@ export function napi_create_function (env: napi_env, utf8name: Pointer<const_cha
 /** @__sig ipppppp */
 export function napi_get_cb_info (env: napi_env, cbinfo: napi_callback_info, argc: Pointer<size_t>, argv: Pointer<napi_value>, this_arg: Pointer<napi_value>, data: void_pp): napi_status {
   $CHECK_ENV!(env)
-  const envObject = emnapiCtx.getEnv(env)!
+  const envObject = emnapiEnv
   if (!cbinfo) return envObject.setLastError(napi_status.napi_invalid_arg)
   const cbinfoValue = emnapiCtx.getCallbackInfo(cbinfo)
 

--- a/packages/emnapi/src/internal.ts
+++ b/packages/emnapi/src/internal.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @stylistic/indent */
 
-import { emnapiCtx } from 'emnapi:shared'
+import { emnapiCtx, emnapiEnv } from 'emnapi:shared'
 import { from64, makeDynCall, makeSetValue } from 'emscripten:parse-tools'
 import { emnapiString } from './string'
 import { emnapiExternalMemory } from './memory'

--- a/packages/emnapi/src/js_native_api.c
+++ b/packages/emnapi/src/js_native_api.c
@@ -29,14 +29,8 @@ static const char* emnapi_error_messages[] = {
   "Cannot run JavaScript",
 };
 
-EMNAPI_INTERNAL_EXTERN void _emnapi_get_last_error_info(napi_env env,
-                                        napi_status* error_code,
-                                        uint32_t* engine_error_code,
-                                        void** engine_reserved);
-
 napi_status napi_get_last_error_info(
     node_api_basic_env basic_env, const napi_extended_error_info** result) {
-  static napi_extended_error_info last_error;
   napi_env env = (napi_env) basic_env;
   CHECK_ENV(env);
   CHECK_ARG(env, result);
@@ -48,21 +42,14 @@ napi_status napi_get_last_error_info(
                 "Count of error messages must match count of error values");
 #endif
 
-  _emnapi_get_last_error_info(env,
-                              &last_error.error_code,
-                              &last_error.engine_error_code,
-                              &last_error.engine_reserved);
+  CHECK_LE(env->last_error.error_code, last_status);
 
-  CHECK_LE(last_error.error_code, last_status);
+  env->last_error.error_message = emnapi_error_messages[env->last_error.error_code];
 
-  last_error.error_message = emnapi_error_messages[last_error.error_code];
-
-  if (last_error.error_code == napi_ok) {
+  if (env->last_error.error_code == napi_ok) {
     napi_clear_last_error(env);
-    last_error.engine_error_code = 0;
-    last_error.engine_reserved = NULL;
   }
-  *result = &last_error;
+  *result = &(env->last_error);
   return napi_ok;
 }
 

--- a/packages/emnapi/src/life.ts
+++ b/packages/emnapi/src/life.ts
@@ -1,4 +1,4 @@
-import { emnapiCtx } from 'emnapi:shared'
+import { emnapiCtx, emnapiEnv } from 'emnapi:shared'
 import { from64, makeSetValue } from 'emscripten:parse-tools'
 import { $CHECK_ENV_NOT_IN_GC, $CHECK_ARG, $CHECK_ENV } from './macro'
 
@@ -96,7 +96,7 @@ export function napi_delete_reference (
   ref: napi_ref
 ): napi_status {
   $CHECK_ENV!(env)
-  const envObject = emnapiCtx.getEnv(env)!
+  const envObject = emnapiEnv
   $CHECK_ARG!(envObject, ref)
   emnapiCtx.getRef(ref)!.dispose()
   return envObject.clearLastError()
@@ -161,7 +161,7 @@ export function napi_get_reference_value (
 /** @__sig ippp */
 export function napi_add_env_cleanup_hook (env: napi_env, fun: number, arg: number): napi_status {
   $CHECK_ENV!(env)
-  const envObject = emnapiCtx.getEnv(env)!
+  const envObject = emnapiEnv
   $CHECK_ARG!(envObject, fun)
 
   from64('fun')
@@ -175,7 +175,7 @@ export function napi_add_env_cleanup_hook (env: napi_env, fun: number, arg: numb
 /** @__sig ippp */
 export function napi_remove_env_cleanup_hook (env: napi_env, fun: number, arg: number): napi_status {
   $CHECK_ENV!(env)
-  const envObject = emnapiCtx.getEnv(env)!
+  const envObject = emnapiEnv
   $CHECK_ARG!(envObject, fun)
 
   from64('fun')
@@ -188,12 +188,12 @@ export function napi_remove_env_cleanup_hook (env: napi_env, fun: number, arg: n
 
 /** @__sig vp */
 export function _emnapi_env_ref (env: napi_env): void {
-  const envObject = emnapiCtx.getEnv(env)!
+  const envObject = emnapiEnv
   envObject.ref()
 }
 
 /** @__sig vp */
 export function _emnapi_env_unref (env: napi_env): void {
-  const envObject = emnapiCtx.getEnv(env)!
+  const envObject = emnapiEnv
   envObject.unref()
 }

--- a/packages/emnapi/src/macro.ts
+++ b/packages/emnapi/src/macro.ts
@@ -38,7 +38,7 @@ export function $PREAMBLE (env: napi_env, fn: (envObject: Env) => napi_status): 
 export function $CHECK_ENV_NOT_IN_GC (env: napi_env): any {
   $CHECK_ENV!(env)
   // @ts-expect-error
-  const envObject = emnapiCtx.getEnv(env)!
+  const envObject = emnapiEnv
   envObject.checkGCAccess()
 }
 

--- a/packages/emnapi/src/miscellaneous.ts
+++ b/packages/emnapi/src/miscellaneous.ts
@@ -1,10 +1,10 @@
-import { emnapiCtx } from 'emnapi:shared'
+import { emnapiEnv } from 'emnapi:shared'
 import { from64 } from 'emscripten:parse-tools'
 import { emnapiString } from './string'
 
 /** @__sig ippi */
 export function _emnapi_get_filename (env: napi_env, buf: char_p, len: int): int {
-  const envObject = emnapiCtx.getEnv(env)!
+  const envObject = emnapiEnv
   const filename = (envObject as NodeEnv).filename
   if (!buf) {
     return emnapiString.lengthBytesUTF8(filename)

--- a/packages/emnapi/src/node.ts
+++ b/packages/emnapi/src/node.ts
@@ -1,4 +1,4 @@
-import { emnapiNodeBinding, emnapiCtx } from 'emnapi:shared'
+import { emnapiNodeBinding, emnapiCtx, emnapiEnv } from 'emnapi:shared'
 import { from64, makeSetValue, makeGetValue, POINTER_SIZE } from 'emscripten:parse-tools'
 import { $PREAMBLE, $CHECK_ARG, $GET_RETURN_STATUS } from './macro'
 
@@ -76,7 +76,6 @@ export function _emnapi_node_make_callback (env: napi_env, async_resource: napi_
   })
   if (result) {
     from64('result')
-    const envObject = emnapiCtx.getEnv(env)!
 
     v = emnapiCtx.napiValueFromJsValue(ret)
     makeSetValue('result', 0, 'v', '*')
@@ -199,6 +198,6 @@ export function napi_make_callback (env: napi_env, async_context: Pointer<int64_
 
 /** @__sig vp */
 export function _emnapi_env_check_gc_access (env: napi_env): void {
-  const envObject = emnapiCtx.getEnv(env)!
+  const envObject = emnapiEnv
   envObject.checkGCAccess()
 }

--- a/packages/emnapi/src/promise.ts
+++ b/packages/emnapi/src/promise.ts
@@ -1,4 +1,4 @@
-import { emnapiCtx } from 'emnapi:shared'
+import { emnapiCtx, emnapiEnv } from 'emnapi:shared'
 import { from64, makeSetValue } from 'emscripten:parse-tools'
 import { $PREAMBLE, $CHECK_ARG, $CHECK_ENV_NOT_IN_GC, $GET_RETURN_STATUS } from './macro'
 

--- a/packages/emnapi/src/property.ts
+++ b/packages/emnapi/src/property.ts
@@ -1,4 +1,4 @@
-import { emnapiCtx } from 'emnapi:shared'
+import { emnapiCtx, emnapiEnv } from 'emnapi:shared'
 import { emnapiDefineProperty } from './internal'
 import { $PREAMBLE, $CHECK_ARG, $GET_RETURN_STATUS } from './macro'
 import { emnapiString } from './string'

--- a/packages/emnapi/src/script.ts
+++ b/packages/emnapi/src/script.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @stylistic/indent */
 
-import { emnapiCtx } from 'emnapi:shared'
+import { emnapiCtx, emnapiEnv } from 'emnapi:shared'
 import { from64, makeSetValue } from 'emscripten:parse-tools'
 import { $CHECK_ARG, $GET_RETURN_STATUS, $PREAMBLE } from './macro'
 import { napi_set_last_error } from './util'

--- a/packages/emnapi/src/string.ts
+++ b/packages/emnapi/src/string.ts
@@ -2,7 +2,7 @@
 
 import { wasmMemory } from 'emscripten:runtime'
 import { getUnsharedTextDecoderView, makeSetValue, from64, makeGetValue } from 'emscripten:parse-tools'
-import { emnapiCtx } from 'emnapi:shared'
+import { emnapiCtx, emnapiEnv } from 'emnapi:shared'
 import { $CHECK_NEW_STRING_ARGS } from './macro'
 
 export interface Decoder {

--- a/packages/emnapi/src/threadsafe-function.ts
+++ b/packages/emnapi/src/threadsafe-function.ts
@@ -5,6 +5,7 @@ import { POINTER_SIZE, to64, makeDynCall, from64, makeSetValue, SIZE_TYPE } from
 import { $CHECK_ENV_NOT_IN_GC, $CHECK_ARG } from './macro'
 
 declare var emnapiCtx: Context
+declare var emnapiEnv: Env
 declare var emnapiNodeBinding: NodeBinding | undefined
 declare function __emnapi_node_emit_async_destroy (async_id: double, trigger_async_id: double): void
 declare function __emnapi_node_emit_async_init (
@@ -20,6 +21,7 @@ declare function __emnapi_runtime_keepalive_push (): void
  * @__deps malloc
  * @__deps free
  * @__deps $emnapiCtx
+ * @__deps $emnapiEnv
  * @__deps $emnapiNodeBinding
  * @__deps _emnapi_node_emit_async_destroy
  * @__deps _emnapi_runtime_keepalive_pop
@@ -426,7 +428,7 @@ const emnapiTSFN = {
   destroy (func: number) {
     emnapiTSFN.destroyQueue(func)
     const env = emnapiTSFN.getEnv(func)
-    const envObject = emnapiCtx.getEnv(env)!
+    const envObject = emnapiEnv
     const ref = emnapiTSFN.getRef(func)
     if (ref) {
       emnapiCtx.getRef(ref)!.dispose()
@@ -469,7 +471,7 @@ const emnapiTSFN = {
   },
   finalize (func: number) {
     const env = emnapiTSFN.getEnv(func)
-    const envObject = emnapiCtx.getEnv(env)!
+    const envObject = emnapiEnv
     emnapiCtx.openScope(envObject)
 
     const finalize = emnapiTSFN.getFinalizeCb(func)
@@ -514,7 +516,7 @@ const emnapiTSFN = {
   },
   closeHandlesAndMaybeDelete (func: number, set_closing: number) {
     const env = emnapiTSFN.getEnv(func)
-    const envObject = emnapiCtx.getEnv(env)!
+    const envObject = emnapiEnv
     emnapiCtx.openScope(envObject)
     try {
       if (set_closing) {
@@ -573,7 +575,7 @@ const emnapiTSFN = {
 
     if (popped_value) {
       const env = emnapiTSFN.getEnv(func)
-      const envObject = emnapiCtx.getEnv(env)!
+      const envObject = emnapiEnv
       emnapiCtx.openScope(envObject)
 
       const f = (): void => {

--- a/packages/emnapi/src/typings/emnapi.d.ts
+++ b/packages/emnapi/src/typings/emnapi.d.ts
@@ -9,3 +9,22 @@ declare type Resolver<T> = import('../../../runtime/dist/types/index').Resolver<
 declare type FunctionTemplate = import('../../../runtime/dist/types/index').FunctionTemplate
 
 declare type NodeBinding = typeof import('../../../node/index')
+
+declare interface BaseStruct {
+  __size__: number
+}
+
+declare interface SNapiExtendedErrorInfo extends BaseStruct {
+  error_message: number
+  engine_reserved: number
+  engine_error_code: number
+  error_code: number
+}
+
+declare interface SNapiEnv extends BaseStruct {
+  reserved: number
+  sentinel: number
+  js_vtable: number
+  module_vtable: number
+  last_error: SNapiExtendedErrorInfo
+}

--- a/packages/emnapi/src/util.ts
+++ b/packages/emnapi/src/util.ts
@@ -1,20 +1,21 @@
 import { ENVIRONMENT_IS_NODE, ENVIRONMENT_IS_PTHREAD, runtimeKeepalivePop, runtimeKeepalivePush } from 'emscripten:runtime'
 import { from64, makeSetValue, makeDynCall } from 'emscripten:parse-tools'
-import { emnapiCtx } from 'emnapi:shared'
+import { emnapiCtx, emnapiEnv } from 'emnapi:shared'
 
 /**
  * @__sig ipiip
  */
 export function napi_set_last_error (env: napi_env, error_code: napi_status, engine_error_code: uint32_t, engine_reserved: void_p): napi_status {
-  const envObject = emnapiCtx.getEnv(env)!
-  return envObject.setLastError(error_code, engine_error_code, engine_reserved)
+  const envObject = emnapiEnv
+  from64('engine_reserved')
+  return envObject.setLastError(error_code, engine_error_code, engine_reserved as number)
 }
 
 /**
  * @__sig ip
  */
 export function napi_clear_last_error (env: napi_env): napi_status {
-  const envObject = emnapiCtx.getEnv(env)!
+  const envObject = emnapiEnv
   return envObject.clearLastError()
 }
 
@@ -80,7 +81,7 @@ export function _emnapi_next_tick (callback: number, data: number): void {
  * @__sig vipppi
  */
 export function _emnapi_callback_into_module (forceUncaught: int, env: napi_env, callback: number, data: number, close_scope_if_throw: int): void {
-  const envObject = emnapiCtx.getEnv(env)!
+  const envObject = emnapiEnv
   const scope = emnapiCtx.openScope(envObject)
   try {
     (envObject as NodeEnv).callbackIntoModule(Boolean(forceUncaught), () => {
@@ -100,7 +101,7 @@ export function _emnapi_callback_into_module (forceUncaught: int, env: napi_env,
  * @__sig vipppp
  */
 export function _emnapi_call_finalizer (forceUncaught: int, env: napi_env, callback: number, data: number, hint: number): void {
-  const envObject = emnapiCtx.getEnv(env)!
+  const envObject = emnapiEnv
   from64('callback')
   ;(envObject as NodeEnv).callFinalizerInternal(forceUncaught, callback, data, hint)
 }

--- a/packages/emnapi/src/value-operation.ts
+++ b/packages/emnapi/src/value-operation.ts
@@ -1,4 +1,4 @@
-import { emnapiCtx } from 'emnapi:shared'
+import { emnapiCtx, emnapiEnv } from 'emnapi:shared'
 import { from64, makeSetValue } from 'emscripten:parse-tools'
 import { $CHECK_ENV_NOT_IN_GC, $CHECK_ARG, $PREAMBLE, $GET_RETURN_STATUS } from './macro'
 

--- a/packages/emnapi/src/value/convert2c.ts
+++ b/packages/emnapi/src/value/convert2c.ts
@@ -1,4 +1,4 @@
-import { emnapiCtx } from 'emnapi:shared'
+import { emnapiCtx, emnapiEnv } from 'emnapi:shared'
 import { SIZE_TYPE, from64, makeGetValue, makeSetValue } from 'emscripten:parse-tools'
 import { $emnapiSetValueI64 as emnapiSetValueI64 } from '../util'
 import { emnapiString } from '../string'

--- a/packages/emnapi/src/value/convert2napi.ts
+++ b/packages/emnapi/src/value/convert2napi.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @stylistic/indent */
 
-import { emnapiCtx } from 'emnapi:shared'
+import { emnapiCtx, emnapiEnv } from 'emnapi:shared'
 import { from64, makeGetValue, makeSetValue } from 'emscripten:parse-tools'
 import { emnapiString } from '../string'
 import { $CHECK_ARG, $CHECK_ENV_NOT_IN_GC, $GET_RETURN_STATUS, $PREAMBLE } from '../macro'

--- a/packages/emnapi/src/value/create.ts
+++ b/packages/emnapi/src/value/create.ts
@@ -1,4 +1,4 @@
-import { emnapiCtx } from 'emnapi:shared'
+import { emnapiCtx, emnapiEnv } from 'emnapi:shared'
 import { wasmMemory, _malloc } from 'emscripten:runtime'
 import { from64, makeGetValue, makeSetValue, POINTER_SIZE, to64 } from 'emscripten:parse-tools'
 import { emnapiString } from '../string'

--- a/packages/emnapi/src/value/global.ts
+++ b/packages/emnapi/src/value/global.ts
@@ -1,4 +1,4 @@
-import { emnapiCtx } from 'emnapi:shared'
+import { emnapiCtx, emnapiEnv } from 'emnapi:shared'
 import { from64, makeSetValue } from 'emscripten:parse-tools'
 import { $CHECK_ENV_NOT_IN_GC, $CHECK_ARG } from '../macro'
 

--- a/packages/emnapi/src/version.ts
+++ b/packages/emnapi/src/version.ts
@@ -1,11 +1,11 @@
-import { emnapiCtx } from 'emnapi:shared'
+import { emnapiEnv } from 'emnapi:shared'
 import { makeSetValue } from 'emscripten:parse-tools'
 import { $CHECK_ENV, $CHECK_ARG } from './macro'
 
 /** @__sig ipp */
 export function napi_get_version (env: napi_env, result: Pointer<uint32_t>): napi_status {
   $CHECK_ENV!(env)
-  const envObject = emnapiCtx.getEnv(env)!
+  const envObject = emnapiEnv
   $CHECK_ARG!(envObject, result)
 
   const NODE_API_SUPPORTED_VERSION_MAX = Version.NODE_API_SUPPORTED_VERSION_MAX

--- a/packages/emnapi/src/wrap.ts
+++ b/packages/emnapi/src/wrap.ts
@@ -1,4 +1,4 @@
-import { emnapiCtx } from 'emnapi:shared'
+import { emnapiCtx, emnapiEnv } from 'emnapi:shared'
 import { wasmMemory } from 'emscripten:runtime'
 import { from64, POINTER_SIZE, makeGetValue, POINTER_WASM_TYPE, makeSetValue } from 'emscripten:parse-tools'
 import { emnapiString } from './string'
@@ -212,7 +212,7 @@ export function napi_add_finalizer (env: napi_env, js_object: napi_value, finali
  */
 export function node_api_post_finalizer (env: napi_env, finalize_cb: napi_finalize, finalize_data: void_p, finalize_hint: void_p): napi_status {
   $CHECK_ENV!(env)
-  const envObject = emnapiCtx.getEnv(env)!
+  const envObject = emnapiEnv
   envObject.enqueueFinalizer(
     emnapiCtx.createTrackedFinalizer(
       envObject,

--- a/packages/runtime/src/Finalizer.ts
+++ b/packages/runtime/src/Finalizer.ts
@@ -9,7 +9,7 @@ export class Finalizer {
     private _finalizeData: void_p = 0,
     private _finalizeHint: void_p = 0
   ) {
-    this._makeDynCall_vppp = envObject.makeDynCall_vppp
+    this._makeDynCall_vppp = envObject.bridge.makeDynCall_vppp
   }
 
   public copy (): Finalizer {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,6 +1,6 @@
 export { createContext, getDefaultContext, Context, type CleanupHookCallbackFunction, type ContextOptions } from './Context'
 export { Disposable } from './Disaposable'
-export { Env, NodeEnv, type IReferenceBinding } from './env'
+export { Env, NodeEnv, type IReferenceBinding, type EnvNativeBridge } from './env'
 export { EmnapiError, NotSupportWeakRefError, NotSupportBufferError } from './errors'
 export { External, isExternal, getExternalValue } from './External'
 export { Finalizer } from './Finalizer'


### PR DESCRIPTION
#192 

- Introduced `emnapiEnv` to replace `emnapiCtx.getEnv(env)` for environment access across various modules.
- Updated memory management functions to utilize the new environment structure.
- Enhanced error handling by integrating `EnvNativeBridge` for better management of last error states.
- Refactored async work and function creation to streamline environment interactions.
- Improved overall code consistency and readability by standardizing environment access patterns.