### PR TITLE
fix: refresh stale shared memory buffer before atomic access (v1.x backport)

### DIFF
--- a/packages/emnapi/src/core/async-work.ts
+++ b/packages/emnapi/src/core/async-work.ts
@@ -41,6 +41,21 @@ var emnapiAWMT = {
     /* napi_async_complete_callback */ complete: 6 * POINTER_SIZE + 24,
     end: 7 * POINTER_SIZE + 24
   },
+  /**
+   * When another thread grows the shared WebAssembly.Memory, this agent's
+   * cached `wasmMemory.buffer` may still have the old shorter length
+   * (V8 refreshes it lazily). If a pointer derived from shared memory lies
+   * beyond the cached length, `wasmMemory.grow(0)` forces the agent to
+   * observe the current memory size and refreshes the buffer.
+   */
+  ensureBufferFor (end: number): ArrayBufferLike {
+    let buffer = wasmMemory.buffer
+    if (end > buffer.byteLength) {
+      wasmMemory.grow(0)
+      buffer = wasmMemory.buffer
+    }
+    return buffer
+  },
   init () {
     emnapiAWMT.pool = []
     emnapiAWMT.workerReady = null
@@ -94,7 +109,7 @@ var emnapiAWMT = {
       from64('emnapiAWMT.globalAddress')
       const size = emnapiAWMT.globalOffset.end
       const addr = emnapiAWMT.globalAddress
-      new Uint8Array(wasmMemory.buffer, addr, size).fill(0)
+      new Uint8Array(emnapiAWMT.ensureBufferFor(addr + size), addr, size).fill(0)
       emnapiAWMT.queueInit(emnapiAWMT.globalAddress + emnapiAWMT.globalOffset.q)
       emnapiAWMT.queueInit(emnapiAWMT.globalAddress + emnapiAWMT.globalOffset.exit_message)
     }
@@ -133,8 +148,8 @@ var emnapiAWMT = {
       }
       from64('index')
 
-      const view = new DataView(wasmMemory.buffer)
       const tidOffset = 20
+      const view = new DataView(emnapiAWMT.ensureBufferFor((index as number) + tidOffset + 4))
       const tid = view.getInt32(index + tidOffset, true)
       worker = PThread.pthreads[tid]
       return worker.whenLoaded!
@@ -162,7 +177,7 @@ var emnapiAWMT = {
     const mutex = {
       lock () {
         const isBrowserMain = typeof window !== 'undefined' && typeof document !== 'undefined' && !ENVIRONMENT_IS_NODE
-        const i32a = new Int32Array(wasmMemory.buffer, index, 1)
+        const i32a = new Int32Array(emnapiAWMT.ensureBufferFor(index + 4), index, 1)
         if (isBrowserMain) {
           while (true) {
             const oldValue = Atomics.compareExchange(i32a, 0, 0, 10)
@@ -181,7 +196,7 @@ var emnapiAWMT = {
         }
       },
       unlock () {
-        const i32a = new Int32Array(wasmMemory.buffer, index, 1)
+        const i32a = new Int32Array(emnapiAWMT.ensureBufferFor(index + 4), index, 1)
         const oldValue = Atomics.compareExchange(i32a, 0, 10, 0)
         if (oldValue !== 10) {
           throw new Error('Tried to unlock while not holding the mutex')
@@ -205,14 +220,14 @@ var emnapiAWMT = {
     const mutex = emnapiAWMT.getMutex()
     const cond = {
       wait () {
-        const i32a = new Int32Array(wasmMemory.buffer, index, 1)
+        const i32a = new Int32Array(emnapiAWMT.ensureBufferFor(index + 4), index, 1)
         const value = Atomics.load(i32a, 0)
         mutex.unlock()
         Atomics.wait(i32a, 0, value)
         mutex.lock()
       },
       signal () {
-        const i32a = new Int32Array(wasmMemory.buffer, index, 1)
+        const i32a = new Int32Array(emnapiAWMT.ensureBufferFor(index + 4), index, 1)
         Atomics.add(i32a, 0, 1)
         Atomics.notify(i32a, 0, 1)
       }
@@ -257,7 +272,7 @@ var emnapiAWMT = {
 
     _emnapi_runtime_keepalive_push()
     emnapiCtx.increaseWaitingRequestCounter()
-    const statusBuffer = new Int32Array(wasmMemory.buffer, work + emnapiAWMT.offset.status, 1)
+    const statusBuffer = new Int32Array(emnapiAWMT.ensureBufferFor(work + emnapiAWMT.offset.status + 4), work + emnapiAWMT.offset.status, 1)
     Atomics.store(statusBuffer, 0, AsyncWorkStatus.Pending)
 
     const mutex = emnapiAWMT.getMutex()
@@ -288,7 +303,7 @@ var emnapiAWMT = {
     if (!cancelled) {
       return napi_status.napi_generic_failure
     }
-    if (Atomics.compareExchange(new Int32Array(wasmMemory.buffer, work + emnapiAWMT.offset.status, 1), 0, AsyncWorkStatus.Pending, AsyncWorkStatus.Cancelled) !== AsyncWorkStatus.Pending) {
+    if (Atomics.compareExchange(new Int32Array(emnapiAWMT.ensureBufferFor(work + emnapiAWMT.offset.status + 4), work + emnapiAWMT.offset.status, 1), 0, AsyncWorkStatus.Pending, AsyncWorkStatus.Cancelled) !== AsyncWorkStatus.Pending) {
       return napi_status.napi_generic_failure
     }
     emnapiCtx.feature.setImmediate(() => {
@@ -316,7 +331,7 @@ var emnapiAWMT = {
         const resource = emnapiAWMT.getResource(work)
         const resource_value = emnapiCtx.refStore.get(resource)!.get()
         const resourceObject = emnapiCtx.handleStore.get(resource_value)!.value
-        const view = new DataView(wasmMemory.buffer)
+        const view = new DataView(emnapiAWMT.ensureBufferFor(work + emnapiAWMT.offset.trigger_async_id + 8))
         const asyncId = view.getFloat64(work + emnapiAWMT.offset.async_id, true)
         const triggerAsyncId = view.getFloat64(work + emnapiAWMT.offset.trigger_async_id, true)
         emnapiNodeBinding.node.makeCallback(resourceObject, callback, [], {
@@ -375,7 +390,7 @@ export var napi_create_async_work = singleThreadAsyncWork
     const aw = _malloc(to64('sizeofAW'))
     if (!aw) return envObject.setLastError(napi_status.napi_generic_failure)
     from64('aw')
-    new Uint8Array(wasmMemory.buffer).subarray(aw, aw + sizeofAW).fill(0)
+    new Uint8Array(emnapiAWMT.ensureBufferFor(aw + sizeofAW)).subarray(aw, aw + sizeofAW).fill(0)
     const s = envObject.ensureHandleId(resourceObject)
     const resourceRef = emnapiCtx.createReference(envObject, s, 1, ReferenceOwnership.kUserland as any)
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -409,7 +424,7 @@ export var napi_delete_async_work = singleThreadAsyncWork
     emnapiCtx.refStore.get(resource)!.dispose()
 
     if (emnapiNodeBinding) {
-      const view = new DataView(wasmMemory.buffer)
+      const view = new DataView(emnapiAWMT.ensureBufferFor(work + emnapiAWMT.offset.trigger_async_id + 8))
       const asyncId = view.getFloat64(work + emnapiAWMT.offset.async_id, true)
       const triggerAsyncId = view.getFloat64(work + emnapiAWMT.offset.trigger_async_id, true)
       _emnapi_node_emit_async_destroy(asyncId, triggerAsyncId)
@@ -471,9 +486,9 @@ export function _emnapi_async_worker (globalAddress: number): number {
   const workerQueueAddr = globalAddress + emnapiAWMT.globalOffset.q
   for (;;) {
     while (emnapiAWMT.queueEmpty(workerQueueAddr)) {
-      Atomics.add(new Int32Array(wasmMemory.buffer, idleThreadsAddr, 1), 0, 1)
+      Atomics.add(new Int32Array(emnapiAWMT.ensureBufferFor(idleThreadsAddr + 4), idleThreadsAddr, 1), 0, 1)
       cond.wait()
-      Atomics.sub(new Int32Array(wasmMemory.buffer, idleThreadsAddr, 1), 0, 1)
+      Atomics.sub(new Int32Array(emnapiAWMT.ensureBufferFor(idleThreadsAddr + 4), idleThreadsAddr, 1), 0, 1)
     }
     const q = makeGetValue('workerQueueAddr', 0, '*')
     if (q === exitMessageAddr) {
@@ -487,7 +502,7 @@ export function _emnapi_async_worker (globalAddress: number): number {
 
     mutex.unlock()
 
-    const statusBuffer = new Int32Array(wasmMemory.buffer, work + emnapiAWMT.offset.status, 1)
+    const statusBuffer = new Int32Array(emnapiAWMT.ensureBufferFor(work + emnapiAWMT.offset.status + 4), work + emnapiAWMT.offset.status, 1)
     if (Atomics.load(statusBuffer, 0) === AsyncWorkStatus.Cancelled) {
       abort('unreachable')
     }

--- a/packages/emnapi/src/core/async-work.ts
+++ b/packages/emnapi/src/core/async-work.ts
@@ -158,18 +158,23 @@ var emnapiAWMT = {
     return emnapiAWMT.workerReady as Promise<any>
   },
   getResource (work: number): number {
+    emnapiAWMT.ensureBufferFor(work + emnapiAWMT.offset.resource + 4)
     return makeGetValue('work', 'emnapiAWMT.offset.resource', '*')
   },
   getExecute (work: number): number {
+    emnapiAWMT.ensureBufferFor(work + emnapiAWMT.offset.execute + 4)
     return makeGetValue('work', 'emnapiAWMT.offset.execute', '*')
   },
   getComplete (work: number): number {
+    emnapiAWMT.ensureBufferFor(work + emnapiAWMT.offset.complete + 4)
     return makeGetValue('work', 'emnapiAWMT.offset.complete', '*')
   },
   getEnv (work: number): number {
+    emnapiAWMT.ensureBufferFor(work + emnapiAWMT.offset.env + 4)
     return makeGetValue('work', 'emnapiAWMT.offset.env', '*')
   },
   getData (work: number): number {
+    emnapiAWMT.ensureBufferFor(work + emnapiAWMT.offset.data + 4)
     return makeGetValue('work', 'emnapiAWMT.offset.data', '*')
   },
   getMutex () {
@@ -235,10 +240,13 @@ var emnapiAWMT = {
     return cond
   },
   queueInit (q: number) {
+    emnapiAWMT.ensureBufferFor(q + POINTER_SIZE + 4)
     makeSetValue('q', 0, 'q', '*')
     makeSetValue('q', POINTER_SIZE, 'q', '*')
   },
   queueInsertTail (h: number, q: number): void {
+    emnapiAWMT.ensureBufferFor(h + POINTER_SIZE + 4)
+    emnapiAWMT.ensureBufferFor(q + POINTER_SIZE + 4)
     makeSetValue('q', 0, 'h', '*')
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const tempValue = makeGetValue('h', POINTER_SIZE, '*')
@@ -249,6 +257,7 @@ var emnapiAWMT = {
     makeSetValue('h', POINTER_SIZE, 'q', '*')
   },
   queueRemove (q: number): void {
+    emnapiAWMT.ensureBufferFor(q + POINTER_SIZE + 4)
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const qprev = makeGetValue('q', POINTER_SIZE, '*')
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -257,6 +266,7 @@ var emnapiAWMT = {
     makeSetValue('qnext', POINTER_SIZE, 'qprev', '*')
   },
   queueEmpty (q: number): boolean {
+    emnapiAWMT.ensureBufferFor(q + 4)
     // eslint-disable-next-line eqeqeq
     return q == makeGetValue('q', 0, '*')
   },
@@ -287,6 +297,7 @@ var emnapiAWMT = {
       throw err
     }
 
+    emnapiAWMT.ensureBufferFor(emnapiAWMT.globalAddress + emnapiAWMT.globalOffset.idle_threads + 4)
     if (makeGetValue('emnapiAWMT.globalAddress', 'emnapiAWMT.globalOffset.idle_threads', 'u32') > 0) {
       cond.signal()
     }
@@ -295,6 +306,7 @@ var emnapiAWMT = {
   cancelWork (work: number) {
     let cancelled = false
     emnapiAWMT.getMutex().execute(() => {
+      emnapiAWMT.ensureBufferFor(work + emnapiAWMT.offset.status + 4)
       cancelled = !emnapiAWMT.queueEmpty(work + emnapiAWMT.offset.queue) && makeGetValue('work', 'emnapiAWMT.offset.status', 'i32') !== AsyncWorkStatus.Completed
       if (cancelled) {
         emnapiAWMT.queueRemove(work + emnapiAWMT.offset.queue)
@@ -485,6 +497,7 @@ export function _emnapi_async_worker (globalAddress: number): number {
   const idleThreadsAddr = globalAddress + emnapiAWMT.globalOffset.idle_threads
   const workerQueueAddr = globalAddress + emnapiAWMT.globalOffset.q
   for (;;) {
+    emnapiAWMT.ensureBufferFor(workerQueueAddr + 4)
     while (emnapiAWMT.queueEmpty(workerQueueAddr)) {
       Atomics.add(new Int32Array(emnapiAWMT.ensureBufferFor(idleThreadsAddr + 4), idleThreadsAddr, 1), 0, 1)
       cond.wait()

--- a/packages/emnapi/src/threadsafe-function.ts
+++ b/packages/emnapi/src/threadsafe-function.ts
@@ -123,7 +123,7 @@ export const emnapiTSFN = {
         const payload = __emnapi__.payload
         if (type === 'tsfn-send') {
           const pendng = payload.tsfn + emnapiTSFN.offset.async_pending
-          if (Atomics.load(new Int32Array(wasmMemory.buffer), pendng >>> 2) !== 0) {
+          if (Atomics.load(new Int32Array(emnapiTSFN.ensureBufferFor(pendng + 4)), pendng >>> 2) !== 0) {
             emnapiTSFN.enqueue(payload.tsfn)
           }
         }
@@ -145,12 +145,27 @@ export const emnapiTSFN = {
     }
     return true
   },
+  /**
+   * When another thread grows the shared WebAssembly.Memory, this agent's
+   * cached `wasmMemory.buffer` may still have the old shorter length
+   * (V8 refreshes it lazily). If a pointer derived from shared memory lies
+   * beyond the cached length, `wasmMemory.grow(0)` forces the agent to
+   * observe the current memory size and refreshes the buffer.
+   */
+  ensureBufferFor (end: number): ArrayBufferLike {
+    let buffer = wasmMemory.buffer
+    if (end > buffer.byteLength) {
+      wasmMemory.grow(0)
+      buffer = wasmMemory.buffer
+    }
+    return buffer
+  },
   initQueue (func: number): boolean {
     const size = 2 * POINTER_SIZE
     const queue = _malloc(to64('size'))
     if (!queue) return false
     from64('queue')
-    new Uint8Array(wasmMemory.buffer, queue, size).fill(0)
+    new Uint8Array(emnapiTSFN.ensureBufferFor(queue + size), queue, size).fill(0)
     emnapiTSFN.storeSizeTypeValue(func + emnapiTSFN.offset.queue, queue, false)
     return true
   },
@@ -257,7 +272,7 @@ export const emnapiTSFN = {
     const mutex = {
       lock () {
         const isBrowserMain = typeof window !== 'undefined' && typeof document !== 'undefined' && !ENVIRONMENT_IS_NODE
-        const i32a = new Int32Array(wasmMemory.buffer, index, 1)
+        const i32a = new Int32Array(emnapiTSFN.ensureBufferFor(index + 4), index, 1)
         if (isBrowserMain) {
           while (true) {
             const oldValue = Atomics.compareExchange(i32a, 0, 0, 10)
@@ -279,7 +294,7 @@ export const emnapiTSFN = {
         return new Promise<void>(resolve => {
           const again = (): void => { fn() }
           const fn = (): void => {
-            const i32a = new Int32Array(wasmMemory.buffer, index, 1)
+            const i32a = new Int32Array(emnapiTSFN.ensureBufferFor(index + 4), index, 1)
             const oldValue = Atomics.compareExchange(i32a, 0, 0, 10)
             if (oldValue === 0) {
               resolve()
@@ -291,7 +306,7 @@ export const emnapiTSFN = {
         })
       }, */
       unlock () {
-        const i32a = new Int32Array(wasmMemory.buffer, index, 1)
+        const i32a = new Int32Array(emnapiTSFN.ensureBufferFor(index + 4), index, 1)
         const oldValue = Atomics.compareExchange(i32a, 0, 10, 0)
         if (oldValue !== 10) {
           throw new Error('Tried to unlock while not holding the mutex')
@@ -325,14 +340,14 @@ export const emnapiTSFN = {
     const mutex = emnapiTSFN.getMutex(func)
     const cond = {
       wait () {
-        const i32a = new Int32Array(wasmMemory.buffer, index, 1)
+        const i32a = new Int32Array(emnapiTSFN.ensureBufferFor(index + 4), index, 1)
         const value = Atomics.load(i32a, 0)
         mutex.unlock()
         Atomics.wait(i32a, 0, value)
         mutex.lock()
       },
       /* waitAsync () {
-        const i32a = new Int32Array(wasmMemory.buffer, index, 1)
+        const i32a = new Int32Array(emnapiTSFN.ensureBufferFor(index + 4), index, 1)
         const value = Atomics.load(i32a, 0)
         mutex.unlock()
         const lock = (): Promise<void> => mutex.lockAsync()
@@ -343,7 +358,7 @@ export const emnapiTSFN = {
         }
       }, */
       signal () {
-        const i32a = new Int32Array(wasmMemory.buffer, index, 1)
+        const i32a = new Int32Array(emnapiTSFN.ensureBufferFor(index + 4), index, 1)
         Atomics.add(i32a, 0, 1)
         Atomics.notify(i32a, 0, 1)
       }
@@ -357,10 +372,10 @@ export const emnapiTSFN = {
     const offset = emnapiTSFN.offset.queue_size
     let arr: any, index: number
 // #if MEMORY64
-    arr = new BigUint64Array(wasmMemory.buffer)
+    arr = new BigUint64Array(emnapiTSFN.ensureBufferFor(func + offset + 8))
     index = (func + offset) >>> 3
 // #else
-    arr = new Uint32Array(wasmMemory.buffer)
+    arr = new Uint32Array(emnapiTSFN.ensureBufferFor(func + offset + 4))
     index = (func + offset) >>> 2
 // #endif
     Atomics.add(arr, index, to64('1') as any)
@@ -369,10 +384,10 @@ export const emnapiTSFN = {
     const offset = emnapiTSFN.offset.queue_size
     let arr: any, index: number
 // #if MEMORY64
-    arr = new BigUint64Array(wasmMemory.buffer)
+    arr = new BigUint64Array(emnapiTSFN.ensureBufferFor(func + offset + 8))
     index = (func + offset) >>> 3
 // #else
-    arr = new Uint32Array(wasmMemory.buffer)
+    arr = new Uint32Array(emnapiTSFN.ensureBufferFor(func + offset + 4))
     index = (func + offset) >>> 2
 // #endif
     Atomics.sub(arr, index, to64('1') as any)
@@ -384,10 +399,10 @@ export const emnapiTSFN = {
     const offset = emnapiTSFN.offset.thread_count
     let arr: any, index: number
 // #if MEMORY64
-    arr = new BigUint64Array(wasmMemory.buffer)
+    arr = new BigUint64Array(emnapiTSFN.ensureBufferFor(func + offset + 8))
     index = (func + offset) >>> 3
 // #else
-    arr = new Uint32Array(wasmMemory.buffer)
+    arr = new Uint32Array(emnapiTSFN.ensureBufferFor(func + offset + 4))
     index = (func + offset) >>> 2
 // #endif
     Atomics.add(arr, index, to64('1') as any)
@@ -396,28 +411,28 @@ export const emnapiTSFN = {
     const offset = emnapiTSFN.offset.thread_count
     let arr: any, index: number
 // #if MEMORY64
-    arr = new BigUint64Array(wasmMemory.buffer)
+    arr = new BigUint64Array(emnapiTSFN.ensureBufferFor(func + offset + 8))
     index = (func + offset) >>> 3
 // #else
-    arr = new Uint32Array(wasmMemory.buffer)
+    arr = new Uint32Array(emnapiTSFN.ensureBufferFor(func + offset + 4))
     index = (func + offset) >>> 2
 // #endif
     Atomics.sub(arr, index, to64('1') as any)
   },
   getState (func: number): number {
-    return Atomics.load(new Int32Array(wasmMemory.buffer), (func + emnapiTSFN.offset.state) >>> 2)
+    return Atomics.load(new Int32Array(emnapiTSFN.ensureBufferFor(func + emnapiTSFN.offset.state + 4)), (func + emnapiTSFN.offset.state) >>> 2)
   },
   setState (func: number, value: 0 | 1 | 2): void {
-    Atomics.store(new Int32Array(wasmMemory.buffer), (func + emnapiTSFN.offset.state) >>> 2, value)
+    Atomics.store(new Int32Array(emnapiTSFN.ensureBufferFor(func + emnapiTSFN.offset.state + 4)), (func + emnapiTSFN.offset.state) >>> 2, value)
   },
   getHandlesClosing (func: number): number {
-    return Atomics.load(new Int8Array(wasmMemory.buffer), (func + emnapiTSFN.offset.handles_closing))
+    return Atomics.load(new Int8Array(emnapiTSFN.ensureBufferFor(func + emnapiTSFN.offset.handles_closing + 1)), (func + emnapiTSFN.offset.handles_closing))
   },
   setHandlesClosing (func: number, value: 0 | 1): void {
-    Atomics.store(new Int8Array(wasmMemory.buffer), (func + emnapiTSFN.offset.handles_closing), value)
+    Atomics.store(new Int8Array(emnapiTSFN.ensureBufferFor(func + emnapiTSFN.offset.handles_closing + 1)), (func + emnapiTSFN.offset.handles_closing), value)
   },
   getDispatchState (func: number): number {
-    return Atomics.load(new Uint32Array(wasmMemory.buffer), (func + emnapiTSFN.offset.dispatch_state) >>> 2)
+    return Atomics.load(new Uint32Array(emnapiTSFN.ensureBufferFor(func + emnapiTSFN.offset.dispatch_state + 4)), (func + emnapiTSFN.offset.dispatch_state) >>> 2)
   },
   getContext (func: number): number {
     return emnapiTSFN.loadSizeTypeValue(func + emnapiTSFN.offset.context, false)
@@ -448,19 +463,19 @@ export const emnapiTSFN = {
     let arr: any
     if (unsigned) {
 // #if MEMORY64
-      arr = new BigUint64Array(wasmMemory.buffer)
+      arr = new BigUint64Array(emnapiTSFN.ensureBufferFor(offset + 8))
       ret = Number(Atomics.load(arr, offset >>> 3))
 // #else
-      arr = new Uint32Array(wasmMemory.buffer)
+      arr = new Uint32Array(emnapiTSFN.ensureBufferFor(offset + 4))
       ret = Atomics.load(arr, offset >>> 2)
 // #endif
       return ret
     } else {
 // #if MEMORY64
-      arr = new BigInt64Array(wasmMemory.buffer)
+      arr = new BigInt64Array(emnapiTSFN.ensureBufferFor(offset + 8))
       ret = Number(Atomics.load(arr, offset >>> 3))
 // #else
-      arr = new Int32Array(wasmMemory.buffer)
+      arr = new Int32Array(emnapiTSFN.ensureBufferFor(offset + 4))
       ret = Atomics.load(arr, offset >>> 2)
 // #endif
       return ret
@@ -470,19 +485,19 @@ export const emnapiTSFN = {
     let arr: any
     if (unsigned) {
 // #if MEMORY64
-      arr = new BigUint64Array(wasmMemory.buffer)
+      arr = new BigUint64Array(emnapiTSFN.ensureBufferFor(offset + 8))
       Atomics.store(arr, offset >>> 3, BigInt(value) as any)
 // #else
-      arr = new Uint32Array(wasmMemory.buffer)
+      arr = new Uint32Array(emnapiTSFN.ensureBufferFor(offset + 4))
       Atomics.store(arr, offset >>> 2, value)
 // #endif
       return undefined
     } else {
 // #if MEMORY64
-      arr = new BigInt64Array(wasmMemory.buffer)
+      arr = new BigInt64Array(emnapiTSFN.ensureBufferFor(offset + 8))
       Atomics.store(arr, offset >>> 3, BigInt(value >>> 0) as any)
 // #else
-      arr = new Int32Array(wasmMemory.buffer)
+      arr = new Int32Array(emnapiTSFN.ensureBufferFor(offset + 4))
       Atomics.store(arr, offset >>> 2, value >>> 0)
 // #endif
       return undefined
@@ -505,8 +520,9 @@ export const emnapiTSFN = {
       emnapiCtx.removeCleanupHook(envObject, emnapiTSFN.cleanup, func)
       envObject.unref()
 
-      const asyncRefOffset = (func + emnapiTSFN.offset.async_ref) >>> 2
-      const arr = new Uint32Array(wasmMemory.buffer)
+      const asyncRefAddress = func + emnapiTSFN.offset.async_ref
+      const asyncRefOffset = asyncRefAddress >>> 2
+      const arr = new Uint32Array(emnapiTSFN.ensureBufferFor(asyncRefAddress + 4))
       if (Atomics.load(arr, asyncRefOffset) > 0) {
         Atomics.store(arr, asyncRefOffset, 0)
         _emnapi_runtime_keepalive_pop()
@@ -514,7 +530,7 @@ export const emnapiTSFN = {
       }
 
       if (emnapiNodeBinding) {
-        const view = new DataView(wasmMemory.buffer)
+        const view = new DataView(emnapiTSFN.ensureBufferFor(func + emnapiTSFN.offset.trigger_async_id + 8))
         const asyncId = view.getFloat64(func + emnapiTSFN.offset.async_id, true)
         const triggerAsyncId = view.getFloat64(func + emnapiTSFN.offset.trigger_async_id, true)
         _emnapi_node_emit_async_destroy(asyncId, triggerAsyncId)
@@ -586,7 +602,7 @@ export const emnapiTSFN = {
           const resource = emnapiTSFN.getResource(func)
           const resource_value = emnapiCtx.refStore.get(resource)!.get()
           const resourceObject = emnapiCtx.handleStore.get(resource_value)!.value
-          const view = new DataView(wasmMemory.buffer)
+          const view = new DataView(emnapiTSFN.ensureBufferFor(func + emnapiTSFN.offset.trigger_async_id + 8))
           const asyncId = view.getFloat64(func + emnapiTSFN.offset.async_id, true)
           const triggerAsyncId = view.getFloat64(func + emnapiTSFN.offset.trigger_async_id, true)
           emnapiNodeBinding.node.makeCallback(resourceObject, f, [], {
@@ -622,7 +638,7 @@ export const emnapiTSFN = {
         return
       }
       emnapiTSFN.setHandlesClosing(func, 1)
-      Atomics.store(new Int32Array(wasmMemory.buffer), (func + emnapiTSFN.offset.async_pending) >>> 2, 1)
+      Atomics.store(new Int32Array(emnapiTSFN.ensureBufferFor(func + emnapiTSFN.offset.async_pending + 4)), (func + emnapiTSFN.offset.async_pending) >>> 2, 1)
       emnapiCtx.feature.setImmediate(() => {
         emnapiTSFN.finalize(func)
       })
@@ -694,7 +710,7 @@ export const emnapiTSFN = {
           const resource = emnapiTSFN.getResource(func)
           const resource_value = emnapiCtx.refStore.get(resource)!.get()
           const resourceObject = emnapiCtx.handleStore.get(resource_value)!.value
-          const view = new DataView(wasmMemory.buffer)
+          const view = new DataView(emnapiTSFN.ensureBufferFor(func + emnapiTSFN.offset.trigger_async_id + 8))
           emnapiNodeBinding.node.makeCallback(resourceObject, f, [], {
             asyncId: view.getFloat64(func + emnapiTSFN.offset.async_id, true),
             triggerAsyncId: view.getFloat64(func + emnapiTSFN.offset.trigger_async_id, true)
@@ -713,8 +729,9 @@ export const emnapiTSFN = {
     let has_more = true
 
     let iterations_left = 1000
-    const ui32a = new Uint32Array(wasmMemory.buffer)
-    const index = (func + emnapiTSFN.offset.dispatch_state) >>> 2
+    const dispatchStateAddress = func + emnapiTSFN.offset.dispatch_state
+    const ui32a = new Uint32Array(emnapiTSFN.ensureBufferFor(dispatchStateAddress + 4))
+    const index = dispatchStateAddress >>> 2
     while (has_more && --iterations_left !== 0) {
       Atomics.store(ui32a, index, 1)
       has_more = emnapiTSFN.dispatchOne(func)
@@ -735,7 +752,7 @@ export const emnapiTSFN = {
     // `scheduled` prevents queueing the same main-thread drain chain more than
     // once while a previous wakeup is still in flight.
     const scheduled = func + emnapiTSFN.offset.async_u_fd
-    const i32a = new Int32Array(wasmMemory.buffer)
+    const i32a = new Int32Array(emnapiTSFN.ensureBufferFor(Math.max(pending, scheduled) + 4))
     if (Atomics.exchange(i32a, scheduled >>> 2, 1) !== 0) {
       return
     }
@@ -780,7 +797,8 @@ export const emnapiTSFN = {
     })
   },
   send (func: number): void {
-    const current_state = Atomics.or(new Uint32Array(wasmMemory.buffer), (func + emnapiTSFN.offset.dispatch_state) >>> 2, 1 << 1)
+    const dispatchStateAddress = func + emnapiTSFN.offset.dispatch_state
+    const current_state = Atomics.or(new Uint32Array(emnapiTSFN.ensureBufferFor(dispatchStateAddress + 4)), dispatchStateAddress >>> 2, 1 << 1)
     if ((current_state & 1) === 1) {
       return
     }
@@ -788,11 +806,11 @@ export const emnapiTSFN = {
     const pendng = func + emnapiTSFN.offset.async_pending
     // A wakeup is already pending, so this send only needs to leave the queued
     // work in the TSFN queue and let the existing drain pick it up.
-    if (Atomics.load(new Int32Array(wasmMemory.buffer), pendng >>> 2) !== 0) {
+    if (Atomics.load(new Int32Array(emnapiTSFN.ensureBufferFor(pendng + 4)), pendng >>> 2) !== 0) {
       return
     }
 
-    if (Atomics.exchange(new Int32Array(wasmMemory.buffer), pendng >>> 2, 1) === 0) {
+    if (Atomics.exchange(new Int32Array(emnapiTSFN.ensureBufferFor(pendng + 4)), pendng >>> 2, 1) === 0) {
       if ((typeof ENVIRONMENT_IS_PTHREAD !== 'undefined') && ENVIRONMENT_IS_PTHREAD) {
         // Worker threads only post a wakeup token. Main-thread draining is
         // serialized by enqueue() once the message is received.
@@ -881,7 +899,7 @@ export function napi_create_threadsafe_function (
   let tsfn = _malloc(to64('sizeofTSFN'))
   if (!tsfn) return envObject.setLastError(napi_status.napi_generic_failure)
   from64('tsfn')
-  new Uint8Array(wasmMemory.buffer).subarray(tsfn, tsfn + sizeofTSFN).fill(0)
+  new Uint8Array(emnapiTSFN.ensureBufferFor(tsfn + sizeofTSFN)).subarray(tsfn, tsfn + sizeofTSFN).fill(0)
   const resourceRef = emnapiCtx.createReference(envObject, resource, 1, ReferenceOwnership.kUserland as any)
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const resource_ = resourceRef.id
@@ -1009,8 +1027,9 @@ export function napi_unref_threadsafe_function (env: napi_env, func: number): na
     return napi_status.napi_invalid_arg
   }
   from64('func')
-  const asyncRefOffset = (func + emnapiTSFN.offset.async_ref) >>> 2
-  const arr = new Uint32Array(wasmMemory.buffer)
+  const asyncRefAddress = func + emnapiTSFN.offset.async_ref
+  const asyncRefOffset = asyncRefAddress >>> 2
+  const arr = new Uint32Array(emnapiTSFN.ensureBufferFor(asyncRefAddress + 4))
   const currentValue = Atomics.load(arr, asyncRefOffset)
   if (currentValue > 0) {
     Atomics.store(arr, asyncRefOffset, currentValue - 1)
@@ -1029,8 +1048,9 @@ export function napi_ref_threadsafe_function (env: napi_env, func: number): napi
     return napi_status.napi_invalid_arg
   }
   from64('func')
-  const asyncRefOffset = (func + emnapiTSFN.offset.async_ref) >>> 2
-  const arr = new Uint32Array(wasmMemory.buffer)
+  const asyncRefAddress = func + emnapiTSFN.offset.async_ref
+  const asyncRefOffset = asyncRefAddress >>> 2
+  const arr = new Uint32Array(emnapiTSFN.ensureBufferFor(asyncRefAddress + 4))
   const currentValue = Atomics.load(arr, asyncRefOffset)
   if (!currentValue) {
     _emnapi_runtime_keepalive_push()

--- a/packages/emnapi/src/threadsafe-function.ts
+++ b/packages/emnapi/src/threadsafe-function.ts
@@ -515,6 +515,7 @@ export const emnapiTSFN = {
       }
       const resource = emnapiTSFN.getResource(func)
       emnapiCtx.refStore.get(resource)!.dispose()
+      emnapiTSFN.ensureBufferFor(func + emnapiTSFN.offset.is_some + 1)
       makeSetValue('func', 'emnapiTSFN.offset.is_some', '0', 'i8')
 
       emnapiCtx.removeCleanupHook(envObject, emnapiTSFN.cleanup, func)

--- a/packages/ts-transform-emscripten-parse-tools/src/index.ts
+++ b/packages/ts-transform-emscripten-parse-tools/src/index.ts
@@ -310,21 +310,10 @@ class Transform {
           this.ctx.factory.createNewExpression(
             this.ctx.factory.createIdentifier('DataView'),
             undefined,
-            [this.ctx.factory.createParenthesizedExpression(this.ctx.factory.createBinaryExpression(
-              this.ctx.factory.createCallExpression(
-                this.ctx.factory.createPropertyAccessExpression(
-                  this.ctx.factory.createIdentifier('wasmMemory'),
-                  this.ctx.factory.createIdentifier('grow')
-                ),
-                undefined,
-                [this.ctx.factory.createNumericLiteral('0')]
-              ),
-              this.ctx.factory.createToken(ts.SyntaxKind.CommaToken),
-              this.ctx.factory.createPropertyAccessExpression(
-                this.ctx.factory.createIdentifier('wasmMemory'),
-                this.ctx.factory.createIdentifier('buffer')
-              )
-            ))]
+            [this.ctx.factory.createPropertyAccessExpression(
+              this.createLazyEmscriptenRuntimeSymbol('wasmMemory'),
+              this.ctx.factory.createIdentifier('buffer')
+            )]
           )
         )],
         ts.NodeFlags.None

--- a/packages/ts-transform-emscripten-parse-tools/src/index.ts
+++ b/packages/ts-transform-emscripten-parse-tools/src/index.ts
@@ -310,10 +310,21 @@ class Transform {
           this.ctx.factory.createNewExpression(
             this.ctx.factory.createIdentifier('DataView'),
             undefined,
-            [this.ctx.factory.createPropertyAccessExpression(
-              this.createLazyEmscriptenRuntimeSymbol('wasmMemory'),
-              this.ctx.factory.createIdentifier('buffer')
-            )]
+            [this.ctx.factory.createParenthesizedExpression(this.ctx.factory.createBinaryExpression(
+              this.ctx.factory.createCallExpression(
+                this.ctx.factory.createPropertyAccessExpression(
+                  this.ctx.factory.createIdentifier('wasmMemory'),
+                  this.ctx.factory.createIdentifier('grow')
+                ),
+                undefined,
+                [this.ctx.factory.createNumericLiteral('0')]
+              ),
+              this.ctx.factory.createToken(ts.SyntaxKind.CommaToken),
+              this.ctx.factory.createPropertyAccessExpression(
+                this.ctx.factory.createIdentifier('wasmMemory'),
+                this.ctx.factory.createIdentifier('buffer')
+              )
+            ))]
           )
         )],
         ts.NodeFlags.None


### PR DESCRIPTION
Fixes #217 — backport of the same change for a 1.x patch release. This is the variant that immediately unblocks `@napi-rs/wasm-runtime` (`^1.7.1`) → `@rolldown/browser` → Vite 8 / WebContainer users (stackblitz/webcontainer-core#2104).

## Problem

TSFN / MT async-work code builds typed-array views from `wasmMemory.buffer` and indexes them with pointers read from shared wasm memory. When another thread grew the shared `WebAssembly.Memory` (via `memory.grow` inside `malloc`), a worker's `wasmMemory.buffer` getter can return a stale, shorter `SharedArrayBuffer` (Chrome 149; V8 refreshes other agents' `Memory` objects lazily). A pointer in the grown region then throws `RangeError: Invalid atomic access index` from `napi_call_threadsafe_function`. Instrumented evidence in #217: at failure time the worker's buffer was 1075904512 bytes while a valid queue pointer was 1078044720; `wasmMemory.grow(0)` refreshed the buffer to 1078067200 and the identical load succeeded.

## Fix

`ensureBufferFor (end)` — refresh via `wasmMemory.grow(0)` only when `end > buffer.byteLength` — threaded through all 43 `wasmMemory.buffer` sites in `packages/emnapi/src/threadsafe-function.ts` and all 14 in `packages/emnapi/src/core/async-work.ts` (wasm32 and MEMORY64 branches). Same change as the `main` PR, resolved against the 1.x API (`refStore.get` / `ensureHandleId` / `feature`).

## Verification

Built `@emnapi/core` from this branch and installed the dist into the failing Rolldown-in-browser repro: 6/6 page-load failures before → 0 failures after (5+ loads + multi-rebuild stress). The built `emnapi-core.esm-bundler.js` diffs against the published 1.11.0 dist only by this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
