### PR TITLE
fix: bind captured setImmediate to the global receiver

### DIFF
--- a/packages/runtime/src/util.ts
+++ b/packages/runtime/src/util.ts
@@ -141,7 +141,7 @@ export function detectFeatures (features?: Partial<Features>): Features {
         })(),
 
     setImmediate: typeof setImmediate === 'function'
-      ? setImmediate
+      ? setImmediate.bind(getGlobalThis())
       : function (callback: () => void): void {
         if (typeof callback !== 'function') {
           throw new TypeError('The "callback" argument must be of type function')


### PR DESCRIPTION
## Problem

Any module using emnapi async work / threadsafe functions throws on Cloudflare
workerd (Workers runtime with `nodejs_compat`) as soon as a callback is
scheduled:

```
TypeError: Illegal invocation: function called with incorrect `this` reference
```

Stack: `napi_call_threadsafe_function -> emnapiTSFN.send -> enqueue -> emnapiCtx.features.setImmediate(...)`.

## Mechanism

`detectFeatures()` captures the bare `setImmediate` global into the `Features`
object (`packages/runtime/src/util.ts`), and every call site invokes it as a
method of that object — `ctx.features.setImmediate(cb)` — so the receiver is
the `Features` object rather than the global scope.

workerd implements `setImmediate` as a method that brand-checks its receiver,
and a non-global receiver fails the check. Node.js does not enforce the
receiver (and per WebIDL an undefined receiver is substituted with the
global), which is why this never showed up in CI or in browsers.

## Context

Hit while running rolldown's napi-rs/emnapi-based WASI build on workerd via
miniflare; downstream consumers currently need a bundler-level
`setImmediate.bind(globalThis)` shim to work around it.
Related: https://github.com/rolldown/rolldown/issues/9464

## Fix

Bind the captured function to `getGlobalThis()` at capture time (same style as
the existing `console.log.bind(console)` in `packages/emnapi/src/core/init.ts`).
The `setTimeout`/`MessageChannel` fallback path is a direct call and is
unaffected; feature detection logic is unchanged. Users can still override
`setImmediate` via the `features` option (the `...features` spread wins).

## Verification

- `npm run build` and the full `packages/test` suite (emscripten Debug,
  including `async`, `tsfn*`, `node-addon-api/threadsafe_function/**`) pass.
- Mechanism proof with a receiver-strict `setImmediate` shim (throws unless
  `this` is the global, mirroring workerd): the old capture pattern throws
  `Illegal invocation`; with this patch, `createContext().features.setImmediate(cb)`
  passes the brand check and the callback fires. Reverting the patch makes the
  same proof fail again with the exact workerd error.

## Note on the 1.x release line

The shipped `@emnapi/runtime` 1.x has the same bare capture, so consumers on
1.x hit the same error on workerd. If you'd like, I'm happy to open a backport
PR against the 1.x line as well — leaving that as a maintainer decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
