### PR TITLE
fix(v8): align internal::Isolate storage to the API pointer size

### DIFF
--- a/packages/emnapi/src/v8/internal.h
+++ b/packages/emnapi/src/v8/internal.h
@@ -24,7 +24,13 @@ struct HandleScopeData final {
 
 class Isolate {
  private:
-  char data_[1024];
+  // The isolate data is accessed through `internal::Address*`
+  // (e.g. `Internals::GetRootSlot`), so it must be at least
+  // pointer-aligned. Without this, whether the static instance in
+  // `Isolate::GetCurrent()` is sufficiently aligned depends on the
+  // surrounding data layout, and misaligned wasm64 i64 loads trap
+  // under SAFE_HEAP=1 (alignment fault).
+  alignas(kApiSystemPointerSize) char data_[1024];
 
  public:
   explicit Isolate();


### PR DESCRIPTION
A one-line alignment fix, split out of the original branch so it can be reviewed on its own.

`v8::internal::Isolate` stored its data as a plain `char[1024]` (`alignof` 1), while `Internals::GetRootSlot` reads it through `internal::Address*`. The static instance in `Isolate::GetCurrent()` therefore only *happened* to be 8-aligned on wasm64; the enlarged `v8_hello_world` test binding shifted the data segment so it landed on a 4-aligned address, and the first `ReturnValue::Get()` root load trapped under `SAFE_HEAP=1` with `Aborted(alignment fault)`.

Declaring the buffer `alignas(kApiSystemPointerSize)` makes correctness no longer depend on surrounding layout.

Verified: reproduced the exact CI stack locally (emsdk 6.0.2, `MEMORY64=1` Debug); after the fix `v8_hello_world` passes on both wasm64 and wasm32 emscripten builds.
