### PR TITLE
feat(runtime): add a require-compatible CJS entry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       run: npm run rebuild -w packages/test
     - name: Test Emscripten ESM library
       run: npm run test -w packages/ts-transform-emscripten-esm-library
+    - name: Test @emnapi/runtime
+      run: npm run test -w packages/runtime
+      timeout-minutes: 1
     - name: Test building Node-API versions
       run: npm run test:version
     - name: Test target

--- a/packages/runtime/.npmignore
+++ b/packages/runtime/.npmignore
@@ -5,6 +5,7 @@ node_modules
 /src
 .gitignore
 .npmignore
+/test
 api-extractor.json
 tsconfig.json
 /dist/types

--- a/packages/runtime/index.cjs
+++ b/packages/runtime/index.cjs
@@ -1,0 +1,63 @@
+'use strict'
+// Mutable CommonJS facade over the ESM build. The v1 package shipped a real
+// CJS entry whose exports object was mutable; generated WASI loaders and
+// @napi-rs/wasm-runtime's runtime.cjs rely on sharing that one mutable
+// exports object (e.g. test harnesses intercept `createContext` around a
+// fresh loader require). The v2 package is ESM-only, and `require()` of an
+// ES module returns a frozen namespace, so restore the contract here. Each
+// export is re-assigned individually (instead of spreading the namespace
+// into `module.exports`) so cjs-module-lexer can statically detect the named
+// exports -- `import()` of this CJS entry must still expose them as module
+// namespace properties. Module-level state (the default-context memoization)
+// lives inside the ESM module itself, so both entries observe the same
+// runtime state.
+const __emnapiRuntime = require('./dist/emnapi.js')
+module.exports.ArrayStore = __emnapiRuntime.ArrayStore
+module.exports.BaseArrayStore = __emnapiRuntime.BaseArrayStore
+module.exports.Context = __emnapiRuntime.Context
+module.exports.CountIdAllocator = __emnapiRuntime.CountIdAllocator
+module.exports.CountIdReuseAllocator = __emnapiRuntime.CountIdReuseAllocator
+module.exports.Disposable = __emnapiRuntime.Disposable
+module.exports.EmnapiError = __emnapiRuntime.EmnapiError
+module.exports.Env = __emnapiRuntime.Env
+module.exports.External = __emnapiRuntime.External
+module.exports.Finalizer = __emnapiRuntime.Finalizer
+module.exports.FunctionTemplate = __emnapiRuntime.FunctionTemplate
+module.exports.HandleScope = __emnapiRuntime.HandleScope
+module.exports.HandleStore = __emnapiRuntime.HandleStore
+module.exports.Isolate = __emnapiRuntime.Isolate
+module.exports.NAPI_VERSION_EXPERIMENTAL = __emnapiRuntime.NAPI_VERSION_EXPERIMENTAL
+module.exports.NODE_API_DEFAULT_MODULE_API_VERSION = __emnapiRuntime.NODE_API_DEFAULT_MODULE_API_VERSION
+module.exports.NODE_API_SUPPORTED_VERSION_MAX = __emnapiRuntime.NODE_API_SUPPORTED_VERSION_MAX
+module.exports.NODE_API_SUPPORTED_VERSION_MIN = __emnapiRuntime.NODE_API_SUPPORTED_VERSION_MIN
+module.exports.NodeEnv = __emnapiRuntime.NodeEnv
+module.exports.NotSupportBufferError = __emnapiRuntime.NotSupportBufferError
+module.exports.NotSupportWeakRefError = __emnapiRuntime.NotSupportWeakRefError
+module.exports.ObjectTemplate = __emnapiRuntime.ObjectTemplate
+module.exports.Persistent = __emnapiRuntime.Persistent
+module.exports.PersistentStore = __emnapiRuntime.PersistentStore
+module.exports.Private = __emnapiRuntime.Private
+module.exports.RefTracker = __emnapiRuntime.RefTracker
+module.exports.Reference = __emnapiRuntime.Reference
+module.exports.ReferenceOwnership = __emnapiRuntime.ReferenceOwnership
+module.exports.ReferenceWithData = __emnapiRuntime.ReferenceWithData
+module.exports.ReferenceWithFinalizer = __emnapiRuntime.ReferenceWithFinalizer
+module.exports.ScopeStore = __emnapiRuntime.ScopeStore
+module.exports.Signature = __emnapiRuntime.Signature
+module.exports.StrongRef = __emnapiRuntime.StrongRef
+module.exports.Template = __emnapiRuntime.Template
+module.exports.TrackedFinalizer = __emnapiRuntime.TrackedFinalizer
+module.exports.TryCatch = __emnapiRuntime.TryCatch
+module.exports.createContext = __emnapiRuntime.createContext
+module.exports.deletePrivate = __emnapiRuntime.deletePrivate
+module.exports.getDefaultContext = __emnapiRuntime.getDefaultContext
+module.exports.getDylinkMetadata = __emnapiRuntime.getDylinkMetadata
+module.exports.getExternalValue = __emnapiRuntime.getExternalValue
+module.exports.getInternalField = __emnapiRuntime.getInternalField
+module.exports.getPrivate = __emnapiRuntime.getPrivate
+module.exports.hasPrivate = __emnapiRuntime.hasPrivate
+module.exports.isExternal = __emnapiRuntime.isExternal
+module.exports.isReferenceType = __emnapiRuntime.isReferenceType
+module.exports.setInternalField = __emnapiRuntime.setInternalField
+module.exports.setPrivate = __emnapiRuntime.setPrivate
+module.exports.version = __emnapiRuntime.version

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -8,14 +8,20 @@
   "types": "./dist/emnapi.d.ts",
   "sideEffects": false,
   "exports": {
-    ".": "./dist/emnapi.js",
+    ".": {
+      "types": "./dist/emnapi.d.ts",
+      "import": "./dist/emnapi.js",
+      "require": "./index.cjs",
+      "default": "./dist/emnapi.js"
+    },
     "./package.json": "./package.json"
   },
   "dependencies": {
     "tslib": "^2.4.0"
   },
   "scripts": {
-    "build": "rollup -c"
+    "build": "rollup -c",
+    "test": "node ./test/index.js"
   },
   "repository": {
     "type": "git",

--- a/packages/runtime/test/index.js
+++ b/packages/runtime/test/index.js
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
+import { pathToFileURL } from 'node:url'
+
+const require = createRequire(import.meta.url)
+
+// 1. require() resolves the CJS facade and exposes exactly the same named
+//    exports as the ESM entry (exact set equality, both directions)
+const cjs = require('@emnapi/runtime')
+const esm = await import('@emnapi/runtime')
+const esmKeys = Object.getOwnPropertyNames(esm).filter(k => k !== 'default').sort()
+const cjsKeys = Object.getOwnPropertyNames(cjs).sort()
+assert.deepStrictEqual(cjsKeys, esmKeys, 'require() export names must exactly match the ESM export names')
+for (const key of esmKeys) {
+  assert.strictEqual(cjs[key], esm[key], `require/import disagree on "${key}"`)
+}
+
+// 2. the exports object is mutable (generated WASI loaders and test harnesses
+//    patch e.g. createContext on the shared require() cache entry)
+const originalCreateContext = cjs.createContext
+const replacement = () => {}
+cjs.createContext = replacement
+assert.strictEqual(cjs.createContext, replacement, 'exports must be mutable')
+assert.strictEqual(require('@emnapi/runtime').createContext, replacement, 'mutation must be visible to other require() consumers')
+cjs.createContext = originalCreateContext
+
+// 3. import() of the CJS entry itself exposes exactly the same named exports
+//    (cjs-module-lexer static detection of the per-name assignments)
+const cjsEntry = pathToFileURL(require.resolve('@emnapi/runtime'))
+assert.match(cjsEntry.pathname, /index\.cjs$/, 'require condition must resolve to index.cjs')
+const nsOfCjs = await import(cjsEntry)
+// 'default' and 'module.exports' are Node's own CJS-ESM interop keys added to
+// import()ed CJS namespaces (not exports of the facade); drop them before the
+// exact comparison
+const nsOfCjsKeys = Object.getOwnPropertyNames(nsOfCjs).filter(k => k !== 'default' && k !== 'module.exports').sort()
+assert.deepStrictEqual(nsOfCjsKeys, esmKeys, 'import() of index.cjs named exports must exactly match the ESM export names')
+
+console.log(`ok - CJS entry exposes ${esmKeys.length} mutable named exports`)


### PR DESCRIPTION
`@emnapi/runtime` v2 is ESM-only, so `require('@emnapi/runtime')` either fails (`ERR_REQUIRE_ESM` on older Node) or hands back a frozen namespace. The v1 package shipped a real CJS entry whose exports object was **mutable** — generated WASI loaders and `@napi-rs/wasm-runtime`'s `runtime.cjs` rely both on `require`-ing `@emnapi/runtime` and on sharing that one mutable exports object. (rolldown currently carries a package patch for exactly this.)

This adds an `index.cjs` facade that:

- requires the ESM build via `require(esm)` (Node 20.19+ / 22.12+) and re-assigns each export individually onto `module.exports`, so `cjs-module-lexer` can statically detect the named exports and consumers can still patch them;
- is wired behind a `"require"` condition in the exports map, so `import` consumers are unaffected;
- keeps all module-level state inside the ESM module, so both entries observe the same runtime state.

A test pins the CJS and ESM export sets to parity (filtered for Node 24's `module.exports` interop marker).

Split out of #220 — it's a module-resolution concern, separate from the memory-view fixes.
