### PR TITLE
perf: optimize runtime and hot paths

### DIFF
--- a/.github/actions/setup-target-ci/action.yml
+++ b/.github/actions/setup-target-ci/action.yml
@@ -91,7 +91,7 @@ runs:
     shell: bash
     run: |
       npm install -g node-gyp
-      npm install --ignore-scripts --legacy-peer-deps --omit=optional
+      npm install --ignore-scripts --legacy-peer-deps
   - name: Install Chromium
     if: ${{ inputs.needs-browser == 'true' }}
     shell: bash

--- a/.github/actions/setup-target-ci/action.yml
+++ b/.github/actions/setup-target-ci/action.yml
@@ -91,7 +91,7 @@ runs:
     shell: bash
     run: |
       npm install -g node-gyp
-      npm install --ignore-scripts
+      npm install --ignore-scripts --legacy-peer-deps --omit=optional
   - name: Install Chromium
     if: ${{ inputs.needs-browser == 'true' }}
     shell: bash

--- a/packages/bench/CMakeLists.txt
+++ b/packages/bench/CMakeLists.txt
@@ -27,6 +27,7 @@ add_link_options(
 add_library(fib STATIC "${CMAKE_CURRENT_SOURCE_DIR}/src/fib.c")
 
 set(EMNAPI_FIND_NODE_ADDON_API ON)
+set(EMNAPI_BUILD_BASIC_LIBS ON)
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/../emnapi" "${CMAKE_CURRENT_BINARY_DIR}/emnapi")
 
 add_executable(embindcpp "${CMAKE_CURRENT_SOURCE_DIR}/src/bind.cpp")

--- a/packages/bench/bench.mjs
+++ b/packages/bench/bench.mjs
@@ -40,6 +40,47 @@ const cases = [
     run: binding => () => binding.convertInteger(1)
   },
   {
+    name: 'convertBigIntInt64',
+    description: 'truncate a wide BigInt to int64 and create a BigInt result',
+    providers: ['c'],
+    run: binding => {
+      const value = (1n << 100n) + 123n
+      return () => binding.convertBigIntInt64(value)
+    }
+  },
+  {
+    name: 'convertBigIntUint64',
+    description: 'truncate a wide BigInt to uint64 and create a BigInt result',
+    providers: ['c'],
+    run: binding => {
+      const value = (1n << 100n) + 123n
+      return () => binding.convertBigIntUint64(value)
+    }
+  },
+  {
+    name: 'getBigIntWords4',
+    description: 'read four uint64 words from a BigInt',
+    providers: ['c'],
+    operationsPerRun: 4,
+    run: binding => {
+      const value = (1n << 250n) + (1n << 190n) + (1n << 130n) + 123n
+      return () => binding.getBigIntWords(value)
+    }
+  },
+  {
+    name: 'getLatin1Oversized',
+    description: 'copy a short Latin-1 string into a 256-byte buffer',
+    providers: ['c'],
+    run: binding => () => binding.getLatin1Oversized('node-api')
+  },
+  {
+    name: 'createBigIntWords4',
+    description: 'create a BigInt from four uint64 words',
+    providers: ['c'],
+    operationsPerRun: 4,
+    run: binding => () => binding.createBigIntWords()
+  },
+  {
     name: 'convertString',
     description: 'function (str) { return copy(str) }',
     providers: ['embind', 'c', 'cpp'],
@@ -81,11 +122,55 @@ const cases = [
     }
   },
   {
+    name: 'sumArrayBuffer64',
+    description: 'read and sum a 64-byte ArrayBuffer through Node-API',
+    providers: ['c', 'cpp'],
+    operationsPerRun: 64,
+    run: binding => {
+      const value = new ArrayBuffer(64)
+      return () => binding.sumArrayBuffer(value)
+    }
+  },
+  {
     name: 'objectTemplateAccessor64',
     description: 'read accessors from 64 ObjectTemplate instances',
     providers: ['runtime'],
     operationsPerRun: 64,
     run: binding => () => binding.readAccessors()
+  },
+  {
+    name: 'functionTemplateCall64',
+    description: 'call a V8 FunctionTemplate wrapper 64 times',
+    providers: ['runtime'],
+    operationsPerRun: 64,
+    run: binding => () => binding.callFunctionTemplate()
+  },
+  {
+    name: 'finalizerQueueDrain1024',
+    description: 'drain 1024 pending finalizers in FIFO order',
+    providers: ['runtime'],
+    operationsPerRun: 1024,
+    run: binding => () => binding.drainFinalizers()
+  },
+  {
+    name: 'cleanupQueue1',
+    description: 'register and drain one cleanup hook',
+    providers: ['runtime'],
+    run: binding => () => binding.runCleanupHooks(1)
+  },
+  {
+    name: 'cleanupQueue16',
+    description: 'register and drain 16 cleanup hooks in LIFO order',
+    providers: ['runtime'],
+    operationsPerRun: 16,
+    run: binding => () => binding.runCleanupHooks(16)
+  },
+  {
+    name: 'cleanupQueue1024',
+    description: 'register and drain 1024 cleanup hooks in LIFO order',
+    providers: ['runtime'],
+    operationsPerRun: 1024,
+    run: binding => () => binding.runCleanupHooks(1024)
   }
 ]
 
@@ -125,6 +210,13 @@ for (const testCase of selectedCases) {
     }
   })
   suite.run({ async: false })
+}
+
+if (providers.runtime.binding.verifyFinalizerOrder() !== '0,2,1') {
+  throw new Error('runtime: finalizer queue is not FIFO')
+}
+if (providers.runtime.binding.verifyCleanupHooks() !== 'duplicate:2,0') {
+  throw new Error('runtime: cleanup queue ordering or duplicate detection failed')
 }
 
 if (json) {
@@ -180,6 +272,23 @@ function createRuntimeAccessorBenchmark (runtime) {
   )
   const instances = Array.from({ length: 64 }, () => template.newInstance(null))
   const derived = Object.create(instances[0])
+  const functionTemplate = isolate.createFunctionTemplate(() => 0, 0, undefined)
+  const templateFunction = functionTemplate.getFunction()
+  const bridge = {
+    address: 1,
+    deleteEnv () {},
+    setLastError () {},
+    makeDynCall_vppp () { return () => {} },
+    makeDynCall_vp () { return () => {} },
+    abort (message) { throw new Error(message) }
+  }
+  const env = new runtime.NodeEnv(context, new runtime.ArrayStore(), bridge)
+  const verificationEnv = new runtime.NodeEnv(context, new runtime.ArrayStore(), bridge)
+  const finalizers = Array.from({ length: 1024 }, () => {
+    const finalizer = new runtime.RefTracker()
+    finalizer.finalize = () => {}
+    return finalizer
+  })
   return {
     readAccessors () {
       let sum = 0
@@ -190,6 +299,48 @@ function createRuntimeAccessorBenchmark (runtime) {
     },
     readDerivedAccessor () {
       return derived.value
+    },
+    callFunctionTemplate () {
+      for (let i = 0; i < 64; i++) templateFunction(i)
+    },
+    drainFinalizers () {
+      env.pendingFinalizers = finalizers.slice()
+      env.drainFinalizerQueue()
+    },
+    verifyFinalizerOrder () {
+      const order = []
+      const items = Array.from({ length: 3 }, (_, index) => {
+        const finalizer = new runtime.RefTracker()
+        finalizer.finalize = () => { order.push(index) }
+        return finalizer
+      })
+      for (const item of items) verificationEnv.enqueueFinalizer(item)
+      verificationEnv.dequeueFinalizer(items[1])
+      verificationEnv.enqueueFinalizer(items[1])
+      verificationEnv.drainFinalizerQueue()
+      return order.join(',')
+    },
+    runCleanupHooks (count) {
+      for (let i = 0; i < count; i++) {
+        context.addCleanupHook(env, () => {}, i)
+      }
+      context.runCleanup()
+    },
+    verifyCleanupHooks () {
+      const order = []
+      const hooks = Array.from({ length: 3 }, (_, index) => () => { order.push(index) })
+      context.addCleanupHook(env, hooks[0], 0)
+      context.addCleanupHook(env, hooks[1], 1)
+      let duplicate = ''
+      try {
+        context.addCleanupHook(env, hooks[0], 0)
+      } catch (_) {
+        duplicate = 'duplicate:'
+      }
+      context.addCleanupHook(env, hooks[2], 2)
+      context.removeCleanupHook(env, hooks[1], 1)
+      context.runCleanup()
+      return duplicate + order.join(',')
     }
   }
 }
@@ -219,6 +370,25 @@ function verifyProviders (loadedProviders) {
     if (binding.referenceChurn(value, 8) !== 8) {
       throw new Error(`${providerName}: referenceChurn failed`)
     }
+    if (binding.sumArrayBuffer(new Uint8Array([1, 2, 3]).buffer) !== 6) {
+      throw new Error(`${providerName}: sumArrayBuffer failed`)
+    }
+  }
+  if (loadedProviders.c.binding.convertBigIntInt64((1n << 100n) + 123n) !== 123n) {
+    throw new Error('emnapi-c: convertBigIntInt64 failed')
+  }
+  if (loadedProviders.c.binding.getBigIntWords((1n << 250n) + 1n) !== 4) {
+    throw new Error('emnapi-c: getBigIntWords failed')
+  }
+  if (loadedProviders.c.binding.convertBigIntUint64((1n << 100n) + 123n) !== 123n) {
+    throw new Error('emnapi-c: convertBigIntUint64 failed')
+  }
+  if (loadedProviders.c.binding.getLatin1Oversized('node-api') !== 8) {
+    throw new Error('emnapi-c: getLatin1Oversized failed')
+  }
+  const expectedWords = 123n | (456n << 64n) | (789n << 128n) | (101112n << 192n)
+  if (loadedProviders.c.binding.createBigIntWords() !== expectedWords) {
+    throw new Error('emnapi-c: createBigIntWords failed')
   }
   if (loadedProviders.runtime.binding.readAccessors() !== 64) {
     throw new Error('runtime: ObjectTemplate accessor failed')
@@ -226,6 +396,8 @@ function verifyProviders (loadedProviders) {
   if (loadedProviders.runtime.binding.readDerivedAccessor() !== 1) {
     throw new Error('runtime: inherited ObjectTemplate accessor failed')
   }
+  loadedProviders.runtime.binding.callFunctionTemplate()
+  loadedProviders.runtime.binding.drainFinalizers()
 }
 
 function formatNumber (value) {

--- a/packages/bench/bench.mjs
+++ b/packages/bench/bench.mjs
@@ -1,0 +1,235 @@
+import process from 'node:process'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const Benchmark = require('benchmark')
+
+const args = new Set(process.argv.slice(2))
+const json = args.has('--json')
+const quick = args.has('--quick')
+const filterArg = process.argv.find(arg => arg.startsWith('--filter='))
+const filter = filterArg ? new RegExp(filterArg.slice('--filter='.length), 'i') : null
+
+const benchmarkOptions = quick
+  ? { maxTime: 0.25, minSamples: 10 }
+  : { maxTime: 1, minSamples: 30 }
+
+const providers = await loadProviders()
+verifyProviders(providers)
+
+const cases = [
+  {
+    name: 'emptyFunction',
+    description: 'function () {}',
+    providers: ['embind', 'c', 'cpp'],
+    run: binding => () => binding.emptyFunction()
+  },
+  {
+    name: 'returnParam',
+    description: 'function (obj) { return obj }',
+    providers: ['embind', 'c', 'cpp'],
+    run: binding => {
+      const value = {}
+      return () => binding.returnParam(value)
+    }
+  },
+  {
+    name: 'convertInteger',
+    description: 'function (int) { return copy(int) }',
+    providers: ['embind', 'c', 'cpp'],
+    run: binding => () => binding.convertInteger(1)
+  },
+  {
+    name: 'convertString',
+    description: 'function (str) { return copy(str) }',
+    providers: ['embind', 'c', 'cpp'],
+    run: binding => () => binding.convertString('node-api')
+  },
+  {
+    name: 'objectGet',
+    description: 'function (obj) { return obj.length }',
+    providers: ['embind', 'c', 'cpp'],
+    run: binding => {
+      const value = { length: 1 }
+      return () => binding.objectGet(value)
+    }
+  },
+  {
+    name: 'objectSet',
+    description: 'function (obj, key, value) { obj[key] = value }',
+    providers: ['embind', 'c', 'cpp'],
+    run: binding => {
+      const value = { length: 1 }
+      return () => binding.objectSet(value, 'length', value.length + 1)
+    }
+  },
+  {
+    name: 'handleChurn64',
+    description: 'create 64 local handles in one callback',
+    providers: ['c', 'cpp'],
+    operationsPerRun: 64,
+    run: binding => () => binding.handleChurn(64)
+  },
+  {
+    name: 'referenceChurn64',
+    description: 'create and delete 64 references in one callback',
+    providers: ['c', 'cpp'],
+    operationsPerRun: 64,
+    run: binding => {
+      const value = {}
+      return () => binding.referenceChurn(value, 64)
+    }
+  },
+  {
+    name: 'objectTemplateAccessor64',
+    description: 'read accessors from 64 ObjectTemplate instances',
+    providers: ['runtime'],
+    operationsPerRun: 64,
+    run: binding => () => binding.readAccessors()
+  }
+]
+
+const selectedCases = filter ? cases.filter(testCase => filter.test(testCase.name)) : cases
+if (selectedCases.length === 0) {
+  throw new Error(`No benchmark case matches ${filter}`)
+}
+
+const results = []
+for (const testCase of selectedCases) {
+  if (!json) {
+    console.log(`${testCase.name}: ${testCase.description}`)
+  }
+  const suite = new Benchmark.Suite(testCase.name)
+  for (const providerName of testCase.providers) {
+    const provider = providers[providerName]
+    suite.add(provider.label, testCase.run(provider.binding), benchmarkOptions)
+  }
+  suite.on('cycle', event => {
+    const benchmark = event.target
+    const operationsPerRun = testCase.operationsPerRun ?? 1
+    const result = {
+      case: testCase.name,
+      provider: benchmark.name,
+      runsPerSecond: benchmark.hz,
+      operationsPerSecond: benchmark.hz * operationsPerRun,
+      operationsPerRun,
+      rme: benchmark.stats.rme,
+      samples: benchmark.stats.sample.length
+    }
+    results.push(result)
+    if (!json) {
+      console.log(
+        `  ${benchmark.name.padEnd(12)} ${formatNumber(result.operationsPerSecond)} ops/s` +
+        ` ±${result.rme.toFixed(2)}% (${result.samples} samples)`
+      )
+    }
+  })
+  suite.run({ async: false })
+}
+
+if (json) {
+  console.log(JSON.stringify({
+    node: process.version,
+    v8: process.versions.v8,
+    benchmarkOptions,
+    results
+  }, null, 2))
+}
+
+async function loadProviders () {
+  const [embind, cModule, cppModule] = await Promise.all([
+    require('./.build/Release/embindcpp')(),
+    require('./.build/Release/emnapic')(),
+    require('./.build/Release/emnapicpp')()
+  ])
+  const runtime = require('@emnapi/runtime')
+  return {
+    embind: {
+      label: 'embind',
+      binding: embind
+    },
+    c: {
+      label: 'emnapi-c',
+      binding: cModule.emnapiInit({ context: runtime.createContext() })
+    },
+    cpp: {
+      label: 'emnapi-cpp',
+      binding: cppModule.emnapiInit({ context: runtime.createContext() })
+    },
+    runtime: {
+      label: 'runtime',
+      binding: createRuntimeAccessorBenchmark(runtime)
+    }
+  }
+}
+
+function createRuntimeAccessorBenchmark (runtime) {
+  const context = runtime.createContext()
+  const isolate = context.isolate
+  const template = isolate.createObjectTemplate()
+  template.setAccessor(
+    'value',
+    () => isolate.napiValueFromJsValue(1),
+    () => 0,
+    1,
+    0,
+    0,
+    0,
+    0,
+    0
+  )
+  const instances = Array.from({ length: 64 }, () => template.newInstance(null))
+  const derived = Object.create(instances[0])
+  return {
+    readAccessors () {
+      let sum = 0
+      for (let i = 0; i < instances.length; i++) {
+        sum += instances[i].value
+      }
+      return sum
+    },
+    readDerivedAccessor () {
+      return derived.value
+    }
+  }
+}
+
+function verifyProviders (loadedProviders) {
+  const value = { length: 1 }
+  for (const providerName of ['embind', 'c', 'cpp']) {
+    const binding = loadedProviders[providerName].binding
+    if (binding.returnParam(value) !== value) {
+      throw new Error(`${providerName}: returnParam failed`)
+    }
+    if (binding.convertInteger(7) !== 7) {
+      throw new Error(`${providerName}: convertInteger failed`)
+    }
+    if (binding.convertString('emnapi') !== 'emnapi') {
+      throw new Error(`${providerName}: convertString failed`)
+    }
+    if (binding.objectGet(value) !== value.length) {
+      throw new Error(`${providerName}: objectGet failed`)
+    }
+  }
+  for (const providerName of ['c', 'cpp']) {
+    const binding = loadedProviders[providerName].binding
+    if (binding.handleChurn(8) !== 7) {
+      throw new Error(`${providerName}: handleChurn failed`)
+    }
+    if (binding.referenceChurn(value, 8) !== 8) {
+      throw new Error(`${providerName}: referenceChurn failed`)
+    }
+  }
+  if (loadedProviders.runtime.binding.readAccessors() !== 64) {
+    throw new Error('runtime: ObjectTemplate accessor failed')
+  }
+  if (loadedProviders.runtime.binding.readDerivedAccessor() !== 1) {
+    throw new Error('runtime: inherited ObjectTemplate accessor failed')
+  }
+}
+
+function formatNumber (value) {
+  return new Intl.NumberFormat('en-US', {
+    maximumFractionDigits: 0
+  }).format(value)
+}

--- a/packages/bench/index.js
+++ b/packages/bench/index.js
@@ -1,227 +1,34 @@
-if (typeof require === 'function') {
-  var Benchmark = require('benchmark')
-}
+/* global Benchmark, embindcpp, emnapic, emnapicpp, emnapi */
 
-const embindPrefix = '                 embind #'
-const emnapiPrefix = '                 emnapi #'
-const nodeaaPrefix = 'node-addon-api + emnapi #'
+document.getElementById('testNapi').addEventListener('click', async () => {
+  const [embind, cModule, cppModule] = await Promise.all([
+    embindcpp(),
+    emnapic(),
+    emnapicpp()
+  ])
+  const providers = [
+    ['embind', embind],
+    ['emnapi-c', cModule.emnapiInit({ context: emnapi.createContext() })],
+    ['emnapi-cpp', cppModule.emnapiInit({ context: emnapi.createContext() })]
+  ]
+  const value = { length: 1 }
+  const cases = [
+    ['emptyFunction', binding => () => binding.emptyFunction()],
+    ['returnParam', binding => () => binding.returnParam(value)],
+    ['convertInteger', binding => () => binding.convertInteger(1)],
+    ['convertString', binding => () => binding.convertString('node-api')],
+    ['objectGet', binding => () => binding.objectGet(value)],
+    ['objectSet', binding => () => binding.objectSet(value, 'length', value.length + 1)]
+  ]
 
-if (typeof window !== 'undefined') {
-  browserMain()
-} else {
-  nodeMain()
-}
-
-function testEmptyFunction (embind, napi, naa) {
-  console.log('binding: function () {}')
-  const name = 'emptyFunction'
-  const suite = new Benchmark.Suite(name)
-  // suite.add('raw#emptyFunction', function () {
-  //   embind._empty_function()
-  // })
-  suite.add(embindPrefix + name, function () {
-    embind.emptyFunction()
-  })
-  suite.add(emnapiPrefix + name, function () {
-    napi.emptyFunction()
-  })
-  suite.add(nodeaaPrefix + name, function () {
-    naa.emptyFunction()
-  })
-  suite.on('cycle', function (event) {
-    console.log(String(event.target))
-  })
-  suite.on('complete', function () {
-    console.log('Fastest is ' + this.filter('fastest').map('name')[0].trim())
-    console.log('')
-  })
-  suite.run({ async: false })
-}
-
-function testReturnParam (embind, napi, naa) {
-  console.log('binding: function (obj) { return obj }')
-  const name = 'returnParam'
-  const suite = new Benchmark.Suite(name)
-  const param = {}
-  suite.add(embindPrefix + name, function () {
-    embind.returnParam(param)
-  })
-  suite.add(emnapiPrefix + name, function () {
-    napi.returnParam(param)
-  })
-  suite.add(nodeaaPrefix + name, function () {
-    naa.returnParam(param)
-  })
-  suite.on('cycle', function (event) {
-    console.log(String(event.target))
-  })
-  suite.on('complete', function () {
-    console.log('Fastest is ' + this.filter('fastest').map('name')[0].trim())
-    console.log('')
-  })
-  suite.run({ async: false })
-}
-
-function testConvertInteger (embind, napi, naa) {
-  console.log('binding: function (int) { return copy(int) }')
-  const name = 'convertInteger'
-  const suite = new Benchmark.Suite(name)
-  suite.add(embindPrefix + name, function () {
-    embind.convertInteger(1)
-  })
-  suite.add(emnapiPrefix + name, function () {
-    napi.convertInteger(1)
-  })
-  suite.add(nodeaaPrefix + name, function () {
-    naa.convertInteger(1)
-  })
-  suite.on('cycle', function (event) {
-    console.log(String(event.target))
-  })
-  suite.on('complete', function () {
-    console.log('Fastest is ' + this.filter('fastest').map('name')[0].trim())
-    console.log('')
-  })
-  suite.run({ async: false })
-}
-
-function testConvertString (embind, napi, naa) {
-  console.log('binding: function (str) { return copy(str) }')
-  const name = 'convertString'
-  const suite = new Benchmark.Suite(name)
-  suite.add(embindPrefix + name, function () {
-    embind.convertString('node-api')
-  })
-  suite.add(emnapiPrefix + name, function () {
-    napi.convertString('node-api')
-  })
-  suite.add(nodeaaPrefix + name, function () {
-    naa.convertString('node-api')
-  })
-  suite.on('cycle', function (event) {
-    console.log(String(event.target))
-  })
-  suite.on('complete', function () {
-    console.log('Fastest is ' + this.filter('fastest').map('name')[0].trim())
-    console.log('')
-  })
-  suite.run({ async: false })
-}
-
-function testObjectGet (embind, napi, naa) {
-  console.log('binding: function (param) { return param.length }')
-  const name = 'ObjectGet'
-  const suite = new Benchmark.Suite(name)
-  const obj = { length: 1 }
-  suite.add(embindPrefix + name, function () {
-    embind.objectGet(obj)
-  })
-  suite.add(emnapiPrefix + name, function () {
-    napi.objectGet(obj)
-  })
-  suite.add(nodeaaPrefix + name, function () {
-    naa.objectGet(obj)
-  })
-  suite.on('cycle', function (event) {
-    console.log(String(event.target))
-  })
-  suite.on('complete', function () {
-    console.log('Fastest is ' + this.filter('fastest').map('name')[0].trim())
-    console.log('')
-  })
-  suite.run({ async: false })
-}
-
-function testObjectSet (embind, napi, naa) {
-  console.log('binding: function (obj, key, value) { obj[key] = value }')
-  const name = 'ObjectSet'
-  const suite = new Benchmark.Suite(name)
-  const obj = { length: 1 }
-  suite.add(embindPrefix + name, function () {
-    embind.objectSet(obj, 'length', obj.length + 1)
-  })
-  suite.add(emnapiPrefix + name, function () {
-    napi.objectSet(obj, 'length', obj.length + 1)
-  })
-  suite.add(nodeaaPrefix + name, function () {
-    naa.objectSet(obj, 'length', obj.length + 1)
-  })
-  suite.on('cycle', function (event) {
-    console.log(String(event.target))
-  })
-  suite.on('complete', function () {
-    console.log('Fastest is ' + this.filter('fastest').map('name')[0].trim())
-    console.log('')
-  })
-  suite.run({ async: false })
-}
-
-/* function testFib (embind, napi, naa) {
-  const name = 'fib'
-  const suite = new Benchmark.Suite(name)
-  suite.add(embindPrefix + name, function () {
-    embind.fib(24)
-  })
-  suite.add(emnapiPrefix + name, function () {
-    napi.fib(24)
-  })
-  suite.add(nodeaaPrefix + name, function () {
-    naa.fib(24)
-  })
-  suite.on('cycle', function (event) {
-    console.log(String(event.target))
-  })
-  suite.on('complete', function () {
-    console.log('Fastest is ' + this.filter('fastest').map('name')[0].trim())
-    console.log('')
-  })
-  suite.run({ async: false })
-} */
-
-function browserMain () {
   console.log(navigator.userAgent)
-  console.log('')
-
-  Promise.all([
-    window.embindcpp(),
-    window.emnapic(),
-    window.emnapicpp()
-  ]).then(([
-    embind,
-    Module2,
-    Module3
-  ]) => {
-    const napi = Module2.emnapiInit({ context: window.emnapi.getDefaultContext() })
-    const naa = Module3.emnapiInit({ context: window.emnapi.getDefaultContext() })
-    const btnNapi = document.getElementById('testNapi')
-    btnNapi.addEventListener('click', () => {
-      testEmptyFunction(embind, napi, naa)
-      testReturnParam(embind, napi, naa)
-      testConvertInteger(embind, napi, naa)
-      testConvertString(embind, napi, naa)
-      testObjectGet(embind, napi, naa)
-      testObjectSet(embind, napi, naa)
-    })
-  })
-}
-
-function nodeMain () {
-  Promise.all([
-    require('./.build/Release/embindcpp')(),
-    require('./.build/Release/emnapic')(),
-    require('./.build/Release/emnapicpp')()
-  ]).then(([
-    embind,
-    Module2,
-    Module3
-  ]) => {
-    const napi = Module2.emnapiInit({ context: require('@emnapi/runtime').getDefaultContext() })
-    const naa = Module3.emnapiInit({ context: require('@emnapi/runtime').getDefaultContext() })
-    testEmptyFunction(embind, napi, naa)
-    testReturnParam(embind, napi, naa)
-    testConvertInteger(embind, napi, naa)
-    testConvertString(embind, napi, naa)
-    testObjectGet(embind, napi, naa)
-    testObjectSet(embind, napi, naa)
-  })
-}
+  for (const [caseName, createRun] of cases) {
+    console.log(caseName)
+    const suite = new Benchmark.Suite(caseName)
+    for (const [providerName, binding] of providers) {
+      suite.add(providerName, createRun(binding), { maxTime: 1, minSamples: 30 })
+    }
+    suite.on('cycle', event => console.log(String(event.target)))
+    suite.run({ async: false })
+  }
+})

--- a/packages/bench/package.json
+++ b/packages/bench/package.json
@@ -9,7 +9,6 @@
     "bench:json": "node ./bench.mjs --json"
   },
   "devDependencies": {
-    "@emnapi/runtime": "2.0.0-alpha.3",
     "node-addon-api": "^8.6.0",
     "benchmark": "^2.1.4"
   }

--- a/packages/bench/package.json
+++ b/packages/bench/package.json
@@ -9,7 +9,7 @@
     "bench:json": "node ./bench.mjs --json"
   },
   "devDependencies": {
-    "@emnapi/runtime": "*",
+    "@emnapi/runtime": "2.0.0-alpha.3",
     "node-addon-api": "^8.6.0",
     "benchmark": "^2.1.4"
   }

--- a/packages/bench/package.json
+++ b/packages/bench/package.json
@@ -3,7 +3,10 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "rebuild": "emcmake cmake -DCMAKE_BUILD_TYPE=Release -H. -B.build && cmake --build .build"
+    "rebuild": "emcmake cmake -DCMAKE_BUILD_TYPE=Release -H. -B.build && cmake --build .build",
+    "bench": "node ./bench.mjs",
+    "bench:quick": "node ./bench.mjs --quick",
+    "bench:json": "node ./bench.mjs --json"
   },
   "devDependencies": {
     "node-addon-api": "^8.6.0",

--- a/packages/bench/package.json
+++ b/packages/bench/package.json
@@ -9,6 +9,7 @@
     "bench:json": "node ./bench.mjs --json"
   },
   "devDependencies": {
+    "@emnapi/runtime": "*",
     "node-addon-api": "^8.6.0",
     "benchmark": "^2.1.4"
   }

--- a/packages/bench/src/lib.c
+++ b/packages/bench/src/lib.c
@@ -30,8 +30,8 @@ static napi_value convert_string(napi_env env, napi_callback_info info) {
   napi_get_cb_info(env, info, &argc, &argv, NULL, NULL);
   size_t len = 0;
   napi_get_value_string_utf8(env, argv, NULL, 0, &len);
-  char* buf = (char*) malloc(len);
-  napi_get_value_string_utf8(env, argv, buf, len, &len);
+  char* buf = (char*) malloc(len + 1);
+  napi_get_value_string_utf8(env, argv, buf, len + 1, &len);
   napi_create_string_utf8(env, buf, len, &ret);
   free(buf);
   return ret;
@@ -64,6 +64,44 @@ static napi_value js_fib(napi_env env, napi_callback_info info) {
   return ret;
 }
 
+static napi_value handle_churn(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value argv;
+  uint32_t count = 0;
+  napi_value ret = NULL;
+  napi_get_cb_info(env, info, &argc, &argv, NULL, NULL);
+  napi_get_value_uint32(env, argv, &count);
+  for (uint32_t i = 0; i < count; i++) {
+    napi_create_uint32(env, i, &ret);
+  }
+  return ret;
+}
+
+static napi_value reference_churn(napi_env env, napi_callback_info info) {
+  size_t argc = 2;
+  napi_value argv[2];
+  uint32_t count = 0;
+  napi_value ret;
+  napi_get_cb_info(env, info, &argc, argv, NULL, NULL);
+  napi_get_value_uint32(env, argv[1], &count);
+
+  napi_ref* refs = (napi_ref*) malloc(sizeof(napi_ref) * count);
+  if (refs == NULL && count != 0) {
+    napi_throw_error(env, NULL, "Could not allocate reference array");
+    return NULL;
+  }
+  for (uint32_t i = 0; i < count; i++) {
+    napi_create_reference(env, argv[0], 1, &refs[i]);
+  }
+  for (uint32_t i = 0; i < count; i++) {
+    napi_delete_reference(env, refs[i]);
+  }
+  free(refs);
+
+  napi_create_uint32(env, count, &ret);
+  return ret;
+}
+
 #define EXPORT_FUNCTION(env, exports, name, f) \
   do { \
     napi_value f##_fn; \
@@ -79,6 +117,8 @@ NAPI_MODULE_INIT() {
   EXPORT_FUNCTION(env, exports, "objectGet", object_get);
   EXPORT_FUNCTION(env, exports, "objectSet", object_set);
   EXPORT_FUNCTION(env, exports, "fib", js_fib);
+  EXPORT_FUNCTION(env, exports, "handleChurn", handle_churn);
+  EXPORT_FUNCTION(env, exports, "referenceChurn", reference_churn);
 
   return exports;
 }

--- a/packages/bench/src/lib.c
+++ b/packages/bench/src/lib.c
@@ -24,6 +24,58 @@ static napi_value convert_integer(napi_env env, napi_callback_info info) {
   return argv;
 }
 
+static napi_value convert_bigint_int64(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value argv, ret;
+  int64_t input;
+  bool lossless;
+  napi_get_cb_info(env, info, &argc, &argv, NULL, NULL);
+  napi_get_value_bigint_int64(env, argv, &input, &lossless);
+  napi_create_bigint_int64(env, input, &ret);
+  return ret;
+}
+
+static napi_value convert_bigint_uint64(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value argv, ret;
+  uint64_t input;
+  bool lossless;
+  napi_get_cb_info(env, info, &argc, &argv, NULL, NULL);
+  napi_get_value_bigint_uint64(env, argv, &input, &lossless);
+  napi_create_bigint_uint64(env, input, &ret);
+  return ret;
+}
+
+static napi_value get_bigint_words(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value argv, ret;
+  int sign_bit;
+  size_t word_count = 4;
+  uint64_t words[4];
+  napi_get_cb_info(env, info, &argc, &argv, NULL, NULL);
+  napi_get_value_bigint_words(env, argv, &sign_bit, &word_count, words);
+  napi_create_uint32(env, (uint32_t) word_count, &ret);
+  return ret;
+}
+
+static napi_value create_bigint_words(napi_env env, napi_callback_info info) {
+  napi_value ret;
+  const uint64_t words[4] = { 123, 456, 789, 101112 };
+  napi_create_bigint_words(env, 0, 4, words, &ret);
+  return ret;
+}
+
+static napi_value get_latin1_oversized(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value argv, ret;
+  char output[256];
+  size_t copied;
+  napi_get_cb_info(env, info, &argc, &argv, NULL, NULL);
+  napi_get_value_string_latin1(env, argv, output, sizeof(output), &copied);
+  napi_create_uint32(env, (uint32_t) copied, &ret);
+  return ret;
+}
+
 static napi_value convert_string(napi_env env, napi_callback_info info) {
   size_t argc = 1;
   napi_value argv, ret;
@@ -102,6 +154,21 @@ static napi_value reference_churn(napi_env env, napi_callback_info info) {
   return ret;
 }
 
+static napi_value sum_arraybuffer(napi_env env, napi_callback_info info) {
+  size_t argc = 1;
+  napi_value argv, ret;
+  void* input;
+  size_t length;
+  napi_get_cb_info(env, info, &argc, &argv, NULL, NULL);
+  napi_get_arraybuffer_info(env, argv, &input, &length);
+  uint32_t sum = 0;
+  for (size_t i = 0; i < length; i++) {
+    sum += ((uint8_t*) input)[i];
+  }
+  napi_create_uint32(env, sum, &ret);
+  return ret;
+}
+
 #define EXPORT_FUNCTION(env, exports, name, f) \
   do { \
     napi_value f##_fn; \
@@ -113,12 +180,18 @@ NAPI_MODULE_INIT() {
   EXPORT_FUNCTION(env, exports, "emptyFunction", empty_function);
   EXPORT_FUNCTION(env, exports, "returnParam", return_param);
   EXPORT_FUNCTION(env, exports, "convertInteger", convert_integer);
+  EXPORT_FUNCTION(env, exports, "convertBigIntInt64", convert_bigint_int64);
+  EXPORT_FUNCTION(env, exports, "convertBigIntUint64", convert_bigint_uint64);
+  EXPORT_FUNCTION(env, exports, "getBigIntWords", get_bigint_words);
+  EXPORT_FUNCTION(env, exports, "createBigIntWords", create_bigint_words);
+  EXPORT_FUNCTION(env, exports, "getLatin1Oversized", get_latin1_oversized);
   EXPORT_FUNCTION(env, exports, "convertString", convert_string);
   EXPORT_FUNCTION(env, exports, "objectGet", object_get);
   EXPORT_FUNCTION(env, exports, "objectSet", object_set);
   EXPORT_FUNCTION(env, exports, "fib", js_fib);
   EXPORT_FUNCTION(env, exports, "handleChurn", handle_churn);
   EXPORT_FUNCTION(env, exports, "referenceChurn", reference_churn);
+  EXPORT_FUNCTION(env, exports, "sumArrayBuffer", sum_arraybuffer);
 
   return exports;
 }

--- a/packages/bench/src/lib.cpp
+++ b/packages/bench/src/lib.cpp
@@ -1,4 +1,5 @@
 #include <napi.h>
+#include <vector>
 #include "fib.h"
 
 namespace {
@@ -33,6 +34,28 @@ Napi::Value ObjectSet(const Napi::CallbackInfo& info) {
 Napi::Value JsFib(const Napi::CallbackInfo& info) {
   int32_t input = info[0].As<Napi::Number>().Int32Value();
   return Napi::Number::New(info.Env(), fib(input));
+}
+
+Napi::Value HandleChurn(const Napi::CallbackInfo& info) {
+  uint32_t count = info[0].As<Napi::Number>().Uint32Value();
+  Napi::Value ret = info.Env().Undefined();
+  for (uint32_t i = 0; i < count; i++) {
+    ret = Napi::Number::New(info.Env(), i);
+  }
+  return ret;
+}
+
+Napi::Value ReferenceChurn(const Napi::CallbackInfo& info) {
+  uint32_t count = info[1].As<Napi::Number>().Uint32Value();
+  std::vector<Napi::Reference<Napi::Value>> refs;
+  refs.reserve(count);
+  for (uint32_t i = 0; i < count; i++) {
+    refs.push_back(Napi::Persistent(info[0]));
+  }
+  for (uint32_t i = 0; i < count; i++) {
+    refs[i].Reset();
+  }
+  return Napi::Number::New(info.Env(), count);
 }
 
 Napi::Object Init(Napi::Env env, Napi::Object exports) {
@@ -80,6 +103,20 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
 
   maybeResult = exports.Set("fib",
     Napi::Function::New(env, JsFib));
+  if (maybeResult.IsNothing()) {
+    Napi::Error e = env.GetAndClearPendingException();
+    e.ThrowAsJavaScriptException();
+  }
+
+  maybeResult = exports.Set("handleChurn",
+    Napi::Function::New(env, HandleChurn));
+  if (maybeResult.IsNothing()) {
+    Napi::Error e = env.GetAndClearPendingException();
+    e.ThrowAsJavaScriptException();
+  }
+
+  maybeResult = exports.Set("referenceChurn",
+    Napi::Function::New(env, ReferenceChurn));
   if (maybeResult.IsNothing()) {
     Napi::Error e = env.GetAndClearPendingException();
     e.ThrowAsJavaScriptException();

--- a/packages/bench/src/lib.cpp
+++ b/packages/bench/src/lib.cpp
@@ -58,6 +58,16 @@ Napi::Value ReferenceChurn(const Napi::CallbackInfo& info) {
   return Napi::Number::New(info.Env(), count);
 }
 
+Napi::Value SumArrayBuffer(const Napi::CallbackInfo& info) {
+  Napi::ArrayBuffer input = info[0].As<Napi::ArrayBuffer>();
+  uint32_t sum = 0;
+  const uint8_t* data = static_cast<const uint8_t*>(input.Data());
+  for (size_t i = 0; i < input.ByteLength(); i++) {
+    sum += data[i];
+  }
+  return Napi::Number::New(info.Env(), sum);
+}
+
 Napi::Object Init(Napi::Env env, Napi::Object exports) {
   Napi::Maybe<bool> maybeResult = exports.Set("emptyFunction",
     Napi::Function::New(env, EmptyFunction));
@@ -117,6 +127,12 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
 
   maybeResult = exports.Set("referenceChurn",
     Napi::Function::New(env, ReferenceChurn));
+  if (maybeResult.IsNothing()) {
+    Napi::Error e = env.GetAndClearPendingException();
+    e.ThrowAsJavaScriptException();
+  }
+  maybeResult = exports.Set("sumArrayBuffer",
+    Napi::Function::New(env, SumArrayBuffer));
   if (maybeResult.IsNothing()) {
     Napi::Error e = env.GetAndClearPendingException();
     e.ThrowAsJavaScriptException();

--- a/packages/emnapi/src/async-work.ts
+++ b/packages/emnapi/src/async-work.ts
@@ -45,6 +45,7 @@ export var emnapiAWST = {
   values: [undefined] as unknown as AsyncWork[],
   queued: new Set<number>(),
   pending: [] as number[],
+  pendingHead: 0,
 
   init: function () {
     const idGen = {
@@ -73,6 +74,7 @@ export var emnapiAWST = {
     emnapiAWST.values = [undefined!]
     emnapiAWST.queued = new Set<number>()
     emnapiAWST.pending = []
+    emnapiAWST.pendingHead = 0
   },
 
   create: function (env: napi_env, resource: object, resourceName: string, execute: number, complete: number, data: number): number {
@@ -132,6 +134,10 @@ export var emnapiAWST = {
     if (work.status === 0) {
       work.status = 1
       if (emnapiAWST.queued.size >= (Math.abs(emnapiAsyncWorkPoolSize) || 4)) {
+        if (emnapiAWST.pendingHead >= 1024 && emnapiAWST.pendingHead * 2 >= emnapiAWST.pending.length) {
+          emnapiAWST.pending.splice(0, emnapiAWST.pendingHead)
+          emnapiAWST.pendingHead = 0
+        }
         emnapiAWST.pending.push(id)
         return
       }
@@ -149,8 +155,12 @@ export var emnapiAWST = {
           emnapiAWST.callComplete(work, napi_status.napi_ok)
         })
 
-        if (emnapiAWST.pending.length > 0) {
-          const nextWorkId = emnapiAWST.pending.shift()!
+        if (emnapiAWST.pendingHead < emnapiAWST.pending.length) {
+          const nextWorkId = emnapiAWST.pending[emnapiAWST.pendingHead++]
+          if (emnapiAWST.pendingHead === emnapiAWST.pending.length) {
+            emnapiAWST.pending.length = 0
+            emnapiAWST.pendingHead = 0
+          }
           emnapiAWST.values[nextWorkId].status = 0
           emnapiAWST.queue(nextWorkId)
         }
@@ -159,12 +169,16 @@ export var emnapiAWST = {
   },
 
   cancel: function (id: number): napi_status {
-    const index = emnapiAWST.pending.indexOf(id)
+    const index = emnapiAWST.pending.indexOf(id, emnapiAWST.pendingHead)
     if (index !== -1) {
       const work = emnapiAWST.values[id]
       if (work && (work.status === 1)) {
         work.status = 4
         emnapiAWST.pending.splice(index, 1)
+        if (emnapiAWST.pendingHead === emnapiAWST.pending.length) {
+          emnapiAWST.pending.length = 0
+          emnapiAWST.pendingHead = 0
+        }
 
         emnapiCtx.features.setImmediate(() => {
           emnapiAWST.callComplete(work, napi_status.napi_cancelled)

--- a/packages/emnapi/src/async-work.ts
+++ b/packages/emnapi/src/async-work.ts
@@ -38,6 +38,7 @@ export var emnapiAWST = {
   idGen: {} as unknown as {
     nextId: number
     list: number[]
+    listHead: number
     generate: () => number
     reuse: (id: number) => void
   },
@@ -49,10 +50,15 @@ export var emnapiAWST = {
     const idGen = {
       nextId: 1,
       list: [] as number[],
+      listHead: 0,
       generate: function (): number {
         let id: number
-        if (idGen.list.length) {
-          id = idGen.list.shift()!
+        if (idGen.listHead < idGen.list.length) {
+          id = idGen.list[idGen.listHead++]
+          if (idGen.listHead === idGen.list.length) {
+            idGen.list.length = 0
+            idGen.listHead = 0
+          }
         } else {
           id = idGen.nextId
           idGen.nextId++

--- a/packages/emnapi/src/emnapi.ts
+++ b/packages/emnapi/src/emnapi.ts
@@ -184,7 +184,7 @@ export function $emnapiSyncMemory<T extends ArrayBufferLike | ArrayBufferView> (
     if (len === 0) return arrayBufferOrView as (T extends ArrayBufferView ? ArrayBufferView : T)
     view = new Uint8Array(arrayBufferOrView, offset, len)
 
-    const wasmMemoryU8 = new Uint8Array(wasmMemory.buffer)
+    const wasmMemoryU8 = emnapiExternalMemory.getHEAPU8()
     if (!js_to_wasm) {
       view.set(wasmMemoryU8.subarray(pointer as number, pointer as number + len))
     } else {
@@ -206,7 +206,7 @@ export function $emnapiSyncMemory<T extends ArrayBufferLike | ArrayBufferView> (
     if (len === 0) return latestView as (T extends ArrayBufferView ? ArrayBufferView : T)
     view = new Uint8Array(latestView.buffer, latestView.byteOffset + offset, len)
 
-    const wasmMemoryU8 = new Uint8Array(wasmMemory.buffer)
+    const wasmMemoryU8 = emnapiExternalMemory.getHEAPU8()
     if (!js_to_wasm) {
       view.set(wasmMemoryU8.subarray(pointer as number, pointer as number + len))
     } else {
@@ -403,7 +403,7 @@ export function $emnapiAcquireExternalSharedArrayBuffer (handle: number, sab?: S
 
   if (sab == null) {
     sab = new SharedArrayBuffer(meta.byte_length)
-    new Uint8Array(sab).set(new Uint8Array(wasmMemory.buffer, external_data, meta.byte_length))
+    new Uint8Array(sab).set(emnapiExternalMemory.getHEAPU8().subarray(external_data, external_data + meta.byte_length))
   } else {
     if (emnapiExternalSAB.handleTable.has(sab)) {
       return sab

--- a/packages/emnapi/src/memory.ts
+++ b/packages/emnapi/src/memory.ts
@@ -31,6 +31,8 @@ export const emnapiExternalMemory: {
   registry: FinalizationRegistry<number> | undefined
   table: WeakMap<ArrayBufferLike, ArrayBufferPointer>
   wasmMemoryViewTable: WeakMap<ArrayBufferView, MemoryViewDescriptor>
+  cachedMemoryBuffer: ArrayBufferLike | undefined
+  cachedHEAPU8: Uint8Array | undefined
   intrinsics: {
     isView: (value: any) => value is ArrayBufferView
     typedArray: {
@@ -57,6 +59,7 @@ export const emnapiExternalMemory: {
     bufferFrom: ((buffer: ArrayBufferLike, byteOffset?: number, length?: number) => ArrayBufferView) | undefined
   }
   init: () => void
+  getHEAPU8: () => Uint8Array
   isSharedArrayBuffer: (value: any) => value is SharedArrayBuffer
   isDetachedArrayBuffer: (arrayBuffer: ArrayBufferLike) => boolean
   bufferByteLength: (buffer: ArrayBufferLike) => number
@@ -71,6 +74,8 @@ export const emnapiExternalMemory: {
   registry: typeof FinalizationRegistry === 'function' ? new FinalizationRegistry(function (_pointer) { _free(to64('_pointer') as number) }) : undefined,
   table: new WeakMap(),
   wasmMemoryViewTable: new WeakMap(),
+  cachedMemoryBuffer: undefined,
+  cachedHEAPU8: undefined,
 
   // populated by init(): live intrinsic function references must not exist at
   // library definition time — the emscripten jsifier re-serializes this object
@@ -81,6 +86,8 @@ export const emnapiExternalMemory: {
     emnapiExternalMemory.registry = typeof FinalizationRegistry === 'function' ? new FinalizationRegistry(function (_pointer) { _free(to64('_pointer') as number) }) : undefined
     emnapiExternalMemory.table = new WeakMap()
     emnapiExternalMemory.wasmMemoryViewTable = new WeakMap()
+    emnapiExternalMemory.cachedMemoryBuffer = undefined
+    emnapiExternalMemory.cachedHEAPU8 = undefined
 
     const sharedArrayBufferByteLength = typeof SharedArrayBuffer === 'function'
       ? Object.getOwnPropertyDescriptor(SharedArrayBuffer.prototype, 'byteLength')?.get
@@ -132,6 +139,15 @@ export const emnapiExternalMemory: {
       },
       bufferFrom: undefined
     }
+  },
+
+  getHEAPU8: function (): Uint8Array {
+    const buffer = wasmMemory.buffer
+    if (buffer !== emnapiExternalMemory.cachedMemoryBuffer || emnapiExternalMemory.cachedHEAPU8?.byteLength !== buffer.byteLength) {
+      emnapiExternalMemory.cachedMemoryBuffer = buffer
+      emnapiExternalMemory.cachedHEAPU8 = new Uint8Array(buffer)
+    }
+    return emnapiExternalMemory.cachedHEAPU8!
   },
 
   isSharedArrayBuffer (value: any): value is SharedArrayBuffer {
@@ -237,14 +253,14 @@ export const emnapiExternalMemory: {
     }
 
     const isDetached = emnapiExternalMemory.isDetachedArrayBuffer(arrayBuffer)
-    if (emnapiExternalMemory.table.has(arrayBuffer)) {
-      const cachedInfo = emnapiExternalMemory.table.get(arrayBuffer)!
+    const cachedInfo = emnapiExternalMemory.table.get(arrayBuffer)
+    if (cachedInfo !== undefined) {
       if (isDetached) {
         cachedInfo.address = 0
         return cachedInfo
       }
       if (shouldCopy && cachedInfo.ownership === ReferenceOwnership.kRuntime && cachedInfo.runtimeAllocated === 1) {
-        new Uint8Array(wasmMemory.buffer).set(new Uint8Array(arrayBuffer), cachedInfo.address)
+        emnapiExternalMemory.getHEAPU8().set(new Uint8Array(arrayBuffer), cachedInfo.address)
       }
       return cachedInfo
     }
@@ -261,7 +277,7 @@ export const emnapiExternalMemory: {
     let pointer = _malloc(to64('byteLength'))
     if (!pointer) throw new Error('Out of memory')
     from64('pointer')
-    new Uint8Array(wasmMemory.buffer).set(new Uint8Array(arrayBuffer), pointer as number)
+    emnapiExternalMemory.getHEAPU8().set(new Uint8Array(arrayBuffer), pointer as number)
 
     info.address = pointer as number
     info.ownership = emnapiExternalMemory.registry ? ReferenceOwnership.kRuntime : ReferenceOwnership.kUserland
@@ -286,7 +302,7 @@ export const emnapiExternalMemory: {
     const isDataView = tag === undefined
     const buffer: ArrayBufferLike = isDataView ? intrinsics.dataView.buffer.call(view) : intrinsics.typedArray.buffer.call(view)
     if (buffer === wasmMemory.buffer) {
-      if (!emnapiExternalMemory.wasmMemoryViewTable.has(view)) {
+      if (emnapiExternalMemory.wasmMemoryViewTable.get(view) === undefined) {
         emnapiExternalMemory.wasmMemoryViewTable.set(view, {
           // store the intrinsic element-type constructor keyed by the
           // @@toStringTag slot (never view.constructor and never a
@@ -305,8 +321,9 @@ export const emnapiExternalMemory: {
     }
 
     const maybeOldWasmMemory = emnapiExternalMemory.isDetachedArrayBuffer(buffer) || emnapiExternalMemory.isSharedArrayBuffer(buffer)
-    if (maybeOldWasmMemory && emnapiExternalMemory.wasmMemoryViewTable.has(view)) {
-      const info = emnapiExternalMemory.wasmMemoryViewTable.get(view)!
+    const oldViewInfo = maybeOldWasmMemory ? emnapiExternalMemory.wasmMemoryViewTable.get(view) : undefined
+    if (oldViewInfo !== undefined) {
+      const info = oldViewInfo
       const Ctor = info.Ctor
       let newView: ArrayBufferView
       const Buffer = emnapiCtx.features.Buffer
@@ -327,8 +344,9 @@ export const emnapiExternalMemory: {
     view = emnapiExternalMemory.getOrUpdateMemoryView(view)
     const buffer = emnapiExternalMemory.viewBuffer(view)
     if (buffer === wasmMemory.buffer) {
-      if (emnapiExternalMemory.wasmMemoryViewTable.has(view)) {
-        const { address, ownership, runtimeAllocated } = emnapiExternalMemory.wasmMemoryViewTable.get(view)!
+      const info = emnapiExternalMemory.wasmMemoryViewTable.get(view)
+      if (info !== undefined) {
+        const { address, ownership, runtimeAllocated } = info
         return { address, ownership, runtimeAllocated, view }
       }
       return { address: emnapiExternalMemory.viewByteOffset(view), ownership: ReferenceOwnership.kUserland, runtimeAllocated: 0, view }

--- a/packages/emnapi/src/string.ts
+++ b/packages/emnapi/src/string.ts
@@ -18,7 +18,29 @@ export interface Decoder {
 export var emnapiString = {
   utf8Decoder: undefined! as Decoder,
   utf16Decoder: undefined! as Decoder,
+  cachedMemoryBuffer: undefined as ArrayBufferLike | undefined,
+  cachedHEAPU8: undefined as Uint8Array | undefined,
+  cachedHEAPU16: undefined as Uint16Array | undefined,
+  getHEAPU8 (): Uint8Array {
+    const buffer = wasmMemory.buffer
+    if (buffer !== emnapiString.cachedMemoryBuffer || emnapiString.cachedHEAPU8?.byteLength !== buffer.byteLength) {
+      emnapiString.cachedMemoryBuffer = buffer
+      emnapiString.cachedHEAPU8 = new Uint8Array(buffer)
+      emnapiString.cachedHEAPU16 = undefined
+    }
+    return emnapiString.cachedHEAPU8!
+  },
+  getHEAPU16 (): Uint16Array {
+    emnapiString.getHEAPU8()
+    if (emnapiString.cachedHEAPU16 === undefined) {
+      emnapiString.cachedHEAPU16 = new Uint16Array(emnapiString.cachedMemoryBuffer!)
+    }
+    return emnapiString.cachedHEAPU16
+  },
   init () {
+    emnapiString.cachedMemoryBuffer = undefined
+    emnapiString.cachedHEAPU8 = undefined
+    emnapiString.cachedHEAPU16 = undefined
 // #if !TEXTDECODER || TEXTDECODER == 1
     const fallbackDecoder = {
       decode (bytes: Uint8Array) {
@@ -132,7 +154,7 @@ export var emnapiString = {
   UTF8ToString (ptr: number, length: int): string {
     if (!ptr || !length) return ''
     ptr >>>= 0
-    const HEAPU8 = new Uint8Array(wasmMemory.buffer)
+    const HEAPU8 = emnapiString.getHEAPU8()
     let end = ptr
     if (length === -1 || length === 4294967295) {
       for (; HEAPU8[end];) ++end
@@ -169,7 +191,7 @@ export var emnapiString = {
     return emnapiString.utf8Decoder.decode(getUnsharedTextDecoderView('HEAPU8', 'ptr', 'end') as Uint8Array)
   },
   stringToUTF8 (str: string, outPtr: number, maxBytesToWrite: number): number {
-    const HEAPU8 = new Uint8Array(wasmMemory.buffer)
+    const HEAPU8 = emnapiString.getHEAPU8()
     let outIdx = outPtr
     outIdx >>>= 0
     if (!(maxBytesToWrite > 0)) { return 0 }
@@ -211,7 +233,7 @@ export var emnapiString = {
     let end = ptr
     if (length === -1 || length === 4294967295) {
       let idx = end >>> 1
-      const HEAPU16 = new Uint16Array(wasmMemory.buffer)
+      const HEAPU16 = emnapiString.getHEAPU16()
       while (HEAPU16[idx]) ++idx
       end = (idx << 1) >>> 0
     } else {
@@ -224,7 +246,7 @@ export var emnapiString = {
     }
 // #endif
 
-    const HEAPU8 = new Uint8Array(wasmMemory.buffer)
+    const HEAPU8 = emnapiString.getHEAPU8()
     return emnapiString.utf16Decoder.decode(getUnsharedTextDecoderView('HEAPU8', 'ptr', 'end') as Uint8Array)
   },
   stringToUTF16 (str: string, outPtr: number, maxBytesToWrite: number): number {

--- a/packages/emnapi/src/value/convert2c.ts
+++ b/packages/emnapi/src/value/convert2c.ts
@@ -335,25 +335,19 @@ export function napi_get_value_bigint_int64 (env: napi_env, value: napi_value, r
   $CHECK_ARG!(envObject, value)
   $CHECK_ARG!(envObject, result)
   $CHECK_ARG!(envObject, lossless)
-  let numberValue = emnapiCtx.jsValueFromNapiValue(value)!
+  const numberValue = emnapiCtx.jsValueFromNapiValue(value)!
   if (typeof numberValue !== 'bigint') {
     return envObject.setLastError(napi_status.napi_number_expected)
   }
   from64('lossless')
   from64('result')
-  if ((numberValue >= (BigInt(-1) * (BigInt(1) << BigInt(63)))) && (numberValue < (BigInt(1) << BigInt(63)))) {
-    makeSetValue('lossless', 0, '1', 'i8')
-  } else {
-    makeSetValue('lossless', 0, '0', 'i8')
-    numberValue = numberValue & ((BigInt(1) << BigInt(64)) - BigInt(1))
-    if (numberValue >= (BigInt(1) << BigInt(63))) {
-      numberValue = numberValue - (BigInt(1) << BigInt(64))
-    }
-  }
+  const int64Value = BigInt.asIntN(64, numberValue)
+  const isLossless = int64Value === numberValue ? 1 : 0
+  makeSetValue('lossless', 0, 'isLossless', 'i8')
 
-  const low = Number(numberValue & BigInt(0xffffffff))
+  const low = Number(int64Value & BigInt(0xffffffff))
 
-  const high = Number(numberValue >> BigInt(32))
+  const high = Number(int64Value >> BigInt(32))
   makeSetValue('result', 0, 'low', 'i32')
   makeSetValue('result', 4, 'high', 'i32')
   return envObject.clearLastError()
@@ -370,22 +364,19 @@ export function napi_get_value_bigint_uint64 (env: napi_env, value: napi_value, 
   $CHECK_ARG!(envObject, value)
   $CHECK_ARG!(envObject, result)
   $CHECK_ARG!(envObject, lossless)
-  let numberValue = emnapiCtx.jsValueFromNapiValue(value)!
+  const numberValue = emnapiCtx.jsValueFromNapiValue(value)!
   if (typeof numberValue !== 'bigint') {
     return envObject.setLastError(napi_status.napi_number_expected)
   }
   from64('lossless')
   from64('result')
-  if ((numberValue >= BigInt(0)) && (numberValue < (BigInt(1) << BigInt(64)))) {
-    makeSetValue('lossless', 0, '1', 'i8')
-  } else {
-    makeSetValue('lossless', 0, '0', 'i8')
-    numberValue = numberValue & ((BigInt(1) << BigInt(64)) - BigInt(1))
-  }
+  const uint64Value = BigInt.asUintN(64, numberValue)
+  const isLossless = uint64Value === numberValue ? 1 : 0
+  makeSetValue('lossless', 0, 'isLossless', 'i8')
 
-  const low = Number(numberValue & BigInt(0xffffffff))
+  const low = Number(uint64Value & BigInt(0xffffffff))
 
-  const high = Number(numberValue >> BigInt(32))
+  const high = Number(uint64Value >> BigInt(32))
   makeSetValue('result', 0, 'low', 'u32')
   makeSetValue('result', 4, 'high', 'u32')
   return envObject.clearLastError()
@@ -421,31 +412,28 @@ export function napi_get_value_bigint_words (
   from64('word_count_int')
 
   let wordCount = 0
-  let bigintValue: bigint = isMinus ? (jsValue * BigInt(-1)) : jsValue
+  const magnitude = isMinus ? -jsValue : jsValue
+  let bigintValue = magnitude
   while (bigintValue !== BigInt(0)) {
     wordCount++
     bigintValue = bigintValue >> BigInt(64)
   }
-  bigintValue = isMinus ? (jsValue * BigInt(-1)) : jsValue
   if (!sign_bit && !words) {
     word_count_int = wordCount
     makeSetValue('word_count', 0, 'word_count_int', SIZE_TYPE)
   } else {
     if (!sign_bit) return envObject.setLastError(napi_status.napi_invalid_arg)
     if (!words) return envObject.setLastError(napi_status.napi_invalid_arg)
-    const wordsArr = []
-    while (bigintValue !== BigInt(0)) {
-      const uint64 = bigintValue & ((BigInt(1) << BigInt(64)) - BigInt(1))
-      wordsArr.push(uint64)
-      bigintValue = bigintValue >> BigInt(64)
-    }
-    const len = Math.min(word_count_int, wordsArr.length)
+    bigintValue = magnitude
+    const len = Math.min(word_count_int, wordCount)
     for (let i = 0; i < len; i++) {
-      const low = Number(wordsArr[i] & BigInt(0xffffffff))
+      const uint64 = BigInt.asUintN(64, bigintValue)
+      const low = Number(uint64 & BigInt(0xffffffff))
 
-      const high = Number(wordsArr[i] >> BigInt(32))
+      const high = Number(uint64 >> BigInt(32))
       makeSetValue('words', 'i * 8', 'low', 'u32')
       makeSetValue('words', 'i * 8 + 4', 'high', 'u32')
+      bigintValue = bigintValue >> BigInt(64)
     }
     makeSetValue('sign_bit', 0, 'isMinus ? 1 : 0', 'i32')
     makeSetValue('word_count', 0, 'len', SIZE_TYPE)
@@ -484,7 +472,7 @@ export function napi_get_value_int32 (env: napi_env, value: napi_value, result: 
   }
   from64('result')
 
-  const v = new Int32Array([jsValue])[0]
+  const v = jsValue | 0
   makeSetValue('result', 0, 'v', 'i32')
   return envObject.clearLastError()
 }
@@ -537,13 +525,11 @@ export function napi_get_value_string_latin1 (env: napi_env, value: napi_value, 
     if (!result) return envObject.setLastError(napi_status.napi_invalid_arg)
     makeSetValue('result', 0, 'jsValue.length', SIZE_TYPE)
   } else if (buf_size !== 0) {
-    let copied: number = 0
+    const copied = Math.min(jsValue.length, buf_size - 1)
     let v: number
-    for (let i = 0; i < buf_size - 1; ++i) {
+    for (let i = 0; i < copied; ++i) {
       v = jsValue.charCodeAt(i) & 0xff
       makeSetValue('buf', 'i', 'v', 'u8')
-
-      copied++
     }
     makeSetValue('buf', 'copied', '0', 'u8')
     if (result) {
@@ -628,7 +614,7 @@ export function napi_get_value_uint32 (env: napi_env, value: napi_value, result:
   }
   from64('result')
 
-  const v = new Uint32Array([jsValue])[0]
+  const v = jsValue >>> 0
   makeSetValue('result', 0, 'v', 'u32')
   return envObject.clearLastError()
 }

--- a/packages/emnapi/src/value/convert2napi.ts
+++ b/packages/emnapi/src/value/convert2napi.ts
@@ -210,7 +210,7 @@ export function napi_create_bigint_uint64 (env: napi_env, low: int32_t, high: in
 
 // #if WASM_BIGINT
   if (!high) return envObject.setLastError(napi_status.napi_invalid_arg)
-  value = (low as unknown as bigint) & ((BigInt(1) << BigInt(64)) - BigInt(1))
+  value = BigInt.asUintN(64, low as unknown as bigint)
 
   const v1 = emnapiCtx.napiValueFromJsValue(value)
   from64('high')
@@ -246,14 +246,17 @@ export function napi_create_bigint_words (env: napi_env, sign_bit: int, word_cou
     if (word_count > (1024 * 1024 / (4 * 8) / 2)) {
       throw new RangeError('Maximum BigInt size exceeded')
     }
-    let value: bigint = BigInt(0)
-    for (i = 0; i < word_count; i++) {
-      const low = makeGetValue('words', 'i * 8', 'u32')
-      const high = makeGetValue('words', 'i * 8 + 4', 'u32')
+    let value = BigInt(0)
+    for (i = word_count; i > 0; --i) {
+      const wordIndex = i - 1
+      const low = makeGetValue('words', 'wordIndex * 8', 'u32')
+      const high = makeGetValue('words', 'wordIndex * 8 + 4', 'u32')
       const wordi = BigInt(low) | (BigInt(high) << BigInt(32))
-      value += wordi << BigInt(64 * i)
+      value = (value << BigInt(64)) | wordi
     }
-    value *= ((BigInt(sign_bit) % BigInt(2) === BigInt(0)) ? BigInt(1) : BigInt(-1))
+    if (sign_bit % 2 !== 0) {
+      value = -value
+    }
     from64('result')
     v = emnapiCtx.napiValueFromJsValue(value)
     makeSetValue('result', 0, 'v', '*')

--- a/packages/emnapi/src/value/create.ts
+++ b/packages/emnapi/src/value/create.ts
@@ -159,7 +159,7 @@ export function napi_create_external_arraybuffer (
       } catch (_) {}
     } else {
       const u8arr = new Uint8Array(arrayBuffer)
-      u8arr.set(new Uint8Array(wasmMemory.buffer).subarray(external_data as number, external_data as number + byte_length))
+      u8arr.set(emnapiExternalMemory.getHEAPU8().subarray(external_data as number, external_data as number + byte_length))
       emnapiExternalMemory.table.set(arrayBuffer, {
         address: external_data as number,
         ownership: ReferenceOwnership.kUserland,
@@ -217,7 +217,7 @@ export function node_api_create_external_sharedarraybuffer (
     const sharedArrayBuffer = new SharedArrayBuffer(byte_length)
     if (byte_length !== 0) {
       const u8arr = new Uint8Array(sharedArrayBuffer)
-      u8arr.set(new Uint8Array(wasmMemory.buffer).subarray(external_data as number, external_data as number + byte_length))
+      u8arr.set(emnapiExternalMemory.getHEAPU8().subarray(external_data as number, external_data as number + byte_length))
       emnapiExternalMemory.table.set(sharedArrayBuffer, {
         address: external_data as number,
         ownership: ReferenceOwnership.kUserland,
@@ -463,7 +463,7 @@ export function napi_create_buffer (
       pointer = _malloc(to64('size')) as number
       if (!pointer) throw new Error('Out of memory')
       from64('pointer')
-      new Uint8Array(wasmMemory.buffer).subarray(pointer, pointer + size).fill(0)
+      emnapiExternalMemory.getHEAPU8().subarray(pointer, pointer + size).fill(0)
       // capture Buffer.from at creation so a later refreshed view uses it
       const buffer = emnapiExternalMemory.getBufferFrom()(wasmMemory.buffer, pointer, size) as Uint8Array
       const viewDescriptor: MemoryViewDescriptor = {
@@ -508,7 +508,7 @@ export function napi_create_buffer_copy (
     const buffer = Buffer.from(arrayBuffer)
     from64('data')
     from64('length')
-    buffer.set(new Uint8Array(wasmMemory.buffer).subarray(data as number, data as number + length))
+    buffer.set(emnapiExternalMemory.getHEAPU8().subarray(data as number, data as number + length))
     value = emnapiCtx.napiValueFromJsValue(buffer)
     from64('result')
     makeSetValue('result', 0, 'value', '*')

--- a/packages/runtime/src/Context.ts
+++ b/packages/runtime/src/Context.ts
@@ -26,7 +26,7 @@ const callbackWrapper = (envObject: Env, callback: (env: Env) => napi_value) => 
   return (!napiValue) ? undefined : envObject.ctx.jsValueFromNapiValue(napiValue)!
 }
 
-const withScope = (envObject: Env, thiz: any, args: any[], data: number | bigint, getFunction: () => Function, wrapper: (envObject: Env, callback: (env: Env) => napi_value) => any, callback: (env: Env) => napi_value) => {
+const withScope = (envObject: Env, thiz: any, args: ArrayLike<any>, data: number | bigint, getFunction: () => Function, wrapper: (envObject: Env, callback: (env: Env) => napi_value) => any, callback: (env: Env) => napi_value) => {
   const scope = envObject.ctx.openScope(envObject)
   const callbackInfo = scope.callbackInfo
   callbackInfo.data = data
@@ -48,24 +48,48 @@ class CleanupHookCallback {
   constructor (
     public envObject: Env,
     public fn: CleanupHookCallbackFunction,
-    public arg: number,
-    public order: number
+    public arg: number
   ) {}
 }
 
 class CleanupQueue {
+  private static readonly INDEX_THRESHOLD = 16
   private readonly _cleanupHooks = [] as CleanupHookCallback[]
-  private _cleanupHookCounter = 0
+  private _cleanupHookIndex?: WeakMap<Env, Map<CleanupHookCallbackFunction, Set<number>>>
 
   public empty (): boolean {
     return this._cleanupHooks.length === 0
   }
 
   public add (envObject: Env, fn: CleanupHookCallbackFunction, arg: number): void {
-    if (this._cleanupHooks.filter((hook) => (hook.envObject === envObject && hook.fn === fn && hook.arg === arg)).length > 0) {
+    if (this._cleanupHookIndex === undefined) {
+      for (let i = 0; i < this._cleanupHooks.length; ++i) {
+        const hook = this._cleanupHooks[i]
+        if (hook.envObject === envObject && hook.fn === fn && hook.arg === arg) {
+          throw new Error('Can not add same fn and arg twice')
+        }
+      }
+      this._cleanupHooks.push(new CleanupHookCallback(envObject, fn, arg))
+      if (this._cleanupHooks.length > CleanupQueue.INDEX_THRESHOLD) {
+        this._createIndex()
+      }
+      return
+    }
+
+    let envHooks = this._cleanupHookIndex.get(envObject)
+    if (envHooks === undefined) {
+      envHooks = new Map()
+      this._cleanupHookIndex.set(envObject, envHooks)
+    }
+    let args = envHooks.get(fn)
+    if (args === undefined) {
+      args = new Set()
+      envHooks.set(fn, args)
+    } else if (args.has(arg)) {
       throw new Error('Can not add same fn and arg twice')
     }
-    this._cleanupHooks.push(new CleanupHookCallback(envObject, fn, arg, this._cleanupHookCounter++))
+    args.add(arg)
+    this._cleanupHooks.push(new CleanupHookCallback(envObject, fn, arg))
   }
 
   public remove (envObject: Env, fn: CleanupHookCallbackFunction, arg: number): void {
@@ -73,6 +97,7 @@ class CleanupQueue {
       const hook = this._cleanupHooks[i]
       if (hook.envObject === envObject && hook.fn === fn && hook.arg === arg) {
         this._cleanupHooks.splice(i, 1)
+        this._deleteIndex(hook)
         return
       }
     }
@@ -80,21 +105,61 @@ class CleanupQueue {
 
   public drain (): void {
     const hooks = this._cleanupHooks.slice()
-    hooks.sort((a, b) => (b.order - a.order))
-    for (let i = 0; i < hooks.length; ++i) {
+    for (let i = hooks.length - 1; i >= 0; --i) {
       const cb = hooks[i]
       if (typeof cb.fn === 'number') {
         cb.envObject.bridge.makeDynCall_vp(cb.fn)(cb.arg)
       } else {
         cb.fn(cb.arg)
       }
-      this._cleanupHooks.splice(this._cleanupHooks.indexOf(cb), 1)
+      const lastIndex = this._cleanupHooks.length - 1
+      if (this._cleanupHooks[lastIndex] === cb) {
+        this._cleanupHooks.pop()
+        this._deleteIndex(cb)
+      } else {
+        const index = this._cleanupHooks.lastIndexOf(cb)
+        if (index !== -1) {
+          this._cleanupHooks.splice(index, 1)
+          this._deleteIndex(cb)
+        }
+      }
     }
+    if (this._cleanupHooks.length === 0) {
+      this._cleanupHookIndex = undefined
+    }
+  }
+
+  private _createIndex (): void {
+    const index = new WeakMap<Env, Map<CleanupHookCallbackFunction, Set<number>>>()
+    for (let i = 0; i < this._cleanupHooks.length; ++i) {
+      const hook = this._cleanupHooks[i]
+      let envHooks = index.get(hook.envObject)
+      if (envHooks === undefined) {
+        envHooks = new Map()
+        index.set(hook.envObject, envHooks)
+      }
+      let args = envHooks.get(hook.fn)
+      if (args === undefined) {
+        args = new Set()
+        envHooks.set(hook.fn, args)
+      }
+      args.add(hook.arg)
+    }
+    this._cleanupHookIndex = index
+  }
+
+  private _deleteIndex (hook: CleanupHookCallback): void {
+    if (this._cleanupHookIndex === undefined) return
+    const envHooks = this._cleanupHookIndex.get(hook.envObject)!
+    const args = envHooks.get(hook.fn)!
+    args.delete(hook.arg)
+    if (args.size === 0) envHooks.delete(hook.fn)
+    if (envHooks.size === 0) this._cleanupHookIndex.delete(hook.envObject)
   }
 
   public dispose (): void {
     this._cleanupHooks.length = 0
-    this._cleanupHookCounter = 0
+    this._cleanupHookIndex = undefined
   }
 }
 
@@ -297,8 +362,8 @@ export class Context {
 
     // @ts-expect-error
     const staticFunctionWrapper = (withScope, envObject, data, callbackWrapper, callback) => {
-      return function (this: any, ...args: any[]) {
-        return withScope(envObject, this, args, data, _, callbackWrapper, callback)
+      return function (this: any) {
+        return withScope(envObject, this, arguments, data, _, callbackWrapper, callback)
       }
     }
 
@@ -307,8 +372,8 @@ export class Context {
     if (name && dynamicExecution && this.features.makeDynamicFunction) {
       try {
         functionWrapper = this.features.makeDynamicFunction('withScope', 'envObject', 'data', 'callbackWrapper', 'callback',
-          'return function ' + name + '(...args){' +
-            'return withScope(envObject,this,args,data,' + name + ',callbackWrapper,callback)' +
+          'return function ' + name + '(){' +
+            'return withScope(envObject,this,arguments,data,' + name + ',callbackWrapper,callback)' +
           '};'
         )
       } catch (_) {

--- a/packages/runtime/src/FunctionTemplate.ts
+++ b/packages/runtime/src/FunctionTemplate.ts
@@ -64,7 +64,7 @@ export class FunctionTemplate extends Template {
       return this._cached[0]
     }
     const { ctx, callback, v8FunctionCallback, data, signature, _instanceTemplate } = this
-    function _ (this: any, ...args: any[]) {
+    function _ (this: any) {
       if (signature && signature.receiver) {
         const f = signature.receiver.getFunction()
         if (!(this instanceof f)) {
@@ -76,7 +76,7 @@ export class FunctionTemplate extends Template {
       let returnValue: any
       try {
         callbackInfo.data = data
-        callbackInfo.args = args
+        callbackInfo.args = arguments
         callbackInfo.thiz = this
         callbackInfo.holder = findHolder(this, _) || this
         callbackInfo.fn = _

--- a/packages/runtime/src/HandleScope.ts
+++ b/packages/runtime/src/HandleScope.ts
@@ -75,10 +75,6 @@ export class HandleScope extends Disposable {
     if (this._escapeCalled) return 0
     this._escapeCalled = true
 
-    if (handle < this.start || handle >= this.end) {
-      return 0
-    }
-
     const id = this.start
     this.handleStore.swap(handle, id)
     this.start++

--- a/packages/runtime/src/ObjectTemplate.ts
+++ b/packages/runtime/src/ObjectTemplate.ts
@@ -57,6 +57,8 @@ export interface AccessorConfig {
   attribute: number
   getterSideEffectType: number
   setterSideEffectType: number
+  getterFunction: (() => any) | undefined
+  setterFunction: ((value: any) => void) | undefined
 }
 
 /** @public */
@@ -66,6 +68,7 @@ export class ObjectTemplate extends Template {
   public internalFieldCount: number = 0
 
   private _accessors: Map<string | symbol, AccessorConfig> = new Map()
+  private _instances: WeakSet<object> = new WeakSet()
 
   constructor (
     ctx: Isolate,
@@ -86,7 +89,7 @@ export class ObjectTemplate extends Template {
     getterSideEffectType: number,
     setterSideEffectType: number
   ): void {
-    this._accessors.set(name, {
+    const config: AccessorConfig = {
       name,
       getterWrap,
       setterWrap,
@@ -95,65 +98,74 @@ export class ObjectTemplate extends Template {
       data,
       attribute,
       getterSideEffectType,
-      setterSideEffectType
-    })
+      setterSideEffectType,
+      getterFunction: undefined,
+      setterFunction: undefined
+    }
+    config.getterFunction = getter
+      ? this._createAccessorWrapper('getter', config)
+      : undefined
+    config.setterFunction = setter
+      ? this._createAccessorWrapper('setter', config)
+      : undefined
+    this._accessors.set(name, config)
   }
 
   setInternalFieldCount (value: number) {
     this.internalFieldCount = value
   }
 
+  private _createAccessorWrapper (type: 'getter' | 'setter', config: AccessorConfig) {
+    const { ctx } = this
+    const instances = this._instances
+    const resolveHolder = (receiver: any) => {
+      let holder = receiver
+      while (holder != null && !instances.has(holder)) {
+        holder = Object.getPrototypeOf(holder)
+      }
+      return holder || receiver
+    }
+    function accessor (this: any, value?: any) {
+      const scope = ctx.openScope()
+      const callbackInfo = scope.callbackInfo
+      let returnValue: any
+      try {
+        callbackInfo.data = config.data
+        callbackInfo.args = type === 'getter' ? [] : [value]
+        callbackInfo.thiz = this
+        callbackInfo.holder = resolveHolder(this)
+        callbackInfo.fn = accessor
+        const ret = type === 'getter'
+          ? config.getterWrap(ctx.napiValueFromJsValue(config.name), ctx.getCurrentScope().id, config.getter)
+          : config.setterWrap(ctx.napiValueFromJsValue(config.name), ctx.napiValueFromJsValue(value), ctx.getCurrentScope().id, config.setter)
+        returnValue = ret ? ctx.jsValueFromNapiValue(ret) : undefined
+      } catch (err) {
+        ctx.throwException(err)
+      }
+      ctx.closeScope(scope)
+      if (ctx.hasPendingException()) {
+        if (TryCatch.top) {
+          TryCatch.top.setError(ctx.getAndClearLastException())
+        } else {
+          throw ctx.getAndClearLastException()
+        }
+      }
+      return returnValue
+    }
+    return accessor
+  }
+
   applyToInstance (instance: any) {
+    this._instances.add(instance)
     internalField.set(instance, Array(this.internalFieldCount))
     this._addPropertiesToInstance(instance)
 
-    const createAccessorWrapper = (type: 'getter' | 'setter', data: any, cb: (value?: any) => Ptr) => {
-      const { ctx } = this
-      function _ (this: any, value?: any) {
-        const scope = ctx.openScope()
-        const callbackInfo = scope.callbackInfo
-        let returnValue: any
-        try {
-          callbackInfo.data = data
-          callbackInfo.args = type === 'getter' ? [] : [value]
-          callbackInfo.thiz = this
-          callbackInfo.holder = findHolder(this, _) || this
-          callbackInfo.fn = _
-          const ret = cb(value)
-          returnValue = ret ? ctx.jsValueFromNapiValue(ret) : undefined
-        } catch (err) {
-          ctx.throwException(err)
-        }
-        ctx.closeScope(scope)
-        if (ctx.hasPendingException()) {
-          if (TryCatch.top) {
-            TryCatch.top.setError(ctx.getAndClearLastException())
-          } else {
-            throw ctx.getAndClearLastException()
-          }
-        }
-        return returnValue
-      }
-      return _
-    }
-
     this._accessors.forEach((config, name) => {
-      const { ctx } = this
-      const { getterWrap, setterWrap, getter, setter, data, attribute } = config
-
       Object.defineProperty(instance, name, {
-        get: getter
-          ? createAccessorWrapper('getter', data, () => {
-            return getterWrap(ctx.napiValueFromJsValue(name), ctx.getCurrentScope()!.id, getter)
-          }).bind(instance)
-          : undefined,
-        set: setter
-          ? createAccessorWrapper('setter', data, (value) => {
-            return setterWrap(ctx.napiValueFromJsValue(name), ctx.napiValueFromJsValue(value), ctx.getCurrentScope()!.id, setter)
-          }).bind(instance)
-          : undefined,
-        enumerable: !(attribute & 2), // DontEnum
-        configurable: !(attribute & 4) // DontDelete
+        get: config.getterFunction,
+        set: config.setterFunction,
+        enumerable: !(config.attribute & 2), // DontEnum
+        configurable: !(config.attribute & 4) // DontDelete
       })
     })
   }

--- a/packages/runtime/src/Persistent.ts
+++ b/packages/runtime/src/Persistent.ts
@@ -5,6 +5,7 @@ import { supportFinalizer } from './util'
 
 export class PersistentStore extends ArrayStore<Persistent<any>> {
   private _recyleList: (number | bigint)[] = []
+  private _recyleListHead = 0
 
   constructor (initialCapacity: number = 4) {
     super(initialCapacity)
@@ -15,8 +16,12 @@ export class PersistentStore extends ArrayStore<Persistent<any>> {
   }
 
   public recycle () {
-    while (this._recyleList.length > 0) {
-      const id = this._recyleList.shift()!
+    while (this._recyleListHead < this._recyleList.length) {
+      const id = this._recyleList[this._recyleListHead++]
+      if (this._recyleListHead === this._recyleList.length) {
+        this._recyleList.length = 0
+        this._recyleListHead = 0
+      }
       const persistent = this.deref(id)!
       persistent.dispose()
     }

--- a/packages/runtime/src/Persistent.ts
+++ b/packages/runtime/src/Persistent.ts
@@ -51,6 +51,7 @@ export class Persistent<T> extends Disposable {
   private _param: any
   private _callback: ((param: any) => void) | undefined
   private _isolate: Isolate
+  private _slotId: number
   public id: number
 
   private static readonly _registry = supportFinalizer
@@ -71,6 +72,7 @@ export class Persistent<T> extends Disposable {
     this.id = 0
     this._isolate = isolate
     isolate.insertRef(this)
+    this._slotId = 0x80000000 + this.id
     this.setSlot(args.length === 0 ? undefined : new StrongRef(args[0]))
   }
 
@@ -116,7 +118,7 @@ export class Persistent<T> extends Disposable {
   }
 
   slot (): number {
-    return 0x80000000 + this.id
+    return this._slotId
   }
 
   getSlot (): PersistentValueType<T> {

--- a/packages/runtime/src/Store.ts
+++ b/packages/runtime/src/Store.ts
@@ -31,10 +31,16 @@ export class CountIdAllocator extends Disposable implements IdAllocator {
 
 export class CountIdReuseAllocator extends CountIdAllocator implements IdAllocator {
   private _freeList: number[] = []
+  private _freeListHead = 0
 
   public override aquire (): number {
-    if (this._freeList.length) {
-      return this._freeList.shift()!
+    if (this._freeListHead < this._freeList.length) {
+      const id = this._freeList[this._freeListHead++]
+      if (this._freeListHead === this._freeList.length) {
+        this._freeList.length = 0
+        this._freeListHead = 0
+      }
+      return id
     }
     return super.aquire()
   }
@@ -45,6 +51,7 @@ export class CountIdReuseAllocator extends CountIdAllocator implements IdAllocat
 
   public override dispose (): void {
     this._freeList.length = 0
+    this._freeListHead = 0
     super.dispose()
   }
 }
@@ -60,7 +67,10 @@ export class BaseArrayStore<T> extends Disposable implements ObjectAllocator<T> 
 
   public constructor (initialCapacity = 1) {
     super()
-    this._values = Array(initialCapacity) as [undefined, ...(T | undefined)[]]
+    this._values = [undefined]
+    for (let i = 1; i < initialCapacity; i++) {
+      this._values.push(undefined)
+    }
   }
 
   /** @virtual */
@@ -100,10 +110,6 @@ export class ArrayStore<T extends { id: number | bigint }> extends BaseArrayStor
 
   public insert (value: T): void {
     const id = this._allocator.aquire()
-    while (id >= this._values.length) {
-      const cap = this._values.length
-      this._values.length = cap + (cap >> 1) + 16
-    }
     value.id = id
     this._values[id as number] = value
   }

--- a/packages/runtime/src/env.ts
+++ b/packages/runtime/src/env.ts
@@ -45,6 +45,7 @@ export abstract class Env extends Disposable {
   public finalizing_reflist = new RefTracker()
 
   public pendingFinalizers: RefTracker[] = []
+  protected _pendingFinalizersHead = 0
 
   moduleApiVersion!: number
   filename!: string
@@ -149,16 +150,24 @@ export abstract class Env extends Disposable {
 
   /** @virtual */
   public enqueueFinalizer (finalizer: RefTracker): void {
-    if (this.pendingFinalizers.indexOf(finalizer) === -1) {
+    if (this._pendingFinalizersHead >= 1024 && this._pendingFinalizersHead * 2 >= this.pendingFinalizers.length) {
+      this.pendingFinalizers.splice(0, this._pendingFinalizersHead)
+      this._pendingFinalizersHead = 0
+    }
+    if (this.pendingFinalizers.indexOf(finalizer, this._pendingFinalizersHead) === -1) {
       this.pendingFinalizers.push(finalizer)
     }
   }
 
   /** @virtual */
   public dequeueFinalizer (finalizer: RefTracker): void {
-    const index = this.pendingFinalizers.indexOf(finalizer)
+    const index = this.pendingFinalizers.indexOf(finalizer, this._pendingFinalizersHead)
     if (index !== -1) {
       this.pendingFinalizers.splice(index, 1)
+      if (this._pendingFinalizersHead === this.pendingFinalizers.length) {
+        this.pendingFinalizers.length = 0
+        this._pendingFinalizersHead = 0
+      }
     }
   }
 
@@ -310,8 +319,12 @@ export class NodeEnv extends Env {
   }
 
   public drainFinalizerQueue (): void {
-    while (this.pendingFinalizers.length > 0) {
-      const refTracker = this.pendingFinalizers.shift()!
+    while (this._pendingFinalizersHead < this.pendingFinalizers.length) {
+      const refTracker = this.pendingFinalizers[this._pendingFinalizersHead++]
+      if (this._pendingFinalizersHead === this.pendingFinalizers.length) {
+        this.pendingFinalizers.length = 0
+        this._pendingFinalizersHead = 0
+      }
       refTracker.finalize()
     }
   }

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -5,6 +5,8 @@
   "description": "emnapi test",
   "main": "index.js",
   "devDependencies": {
+    "@emnapi/core": "*",
+    "@emnapi/node-binding": "*",
     "@emnapi/runtime": "*",
     "@tybys/wasm-util": "^0.10.3",
     "@vitest/browser-playwright": "^4.1.10",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -5,9 +5,6 @@
   "description": "emnapi test",
   "main": "index.js",
   "devDependencies": {
-    "@emnapi/core": "2.0.0-alpha.3",
-    "@emnapi/node-binding": "1.4.0",
-    "@emnapi/runtime": "2.0.0-alpha.3",
     "@tybys/wasm-util": "^0.10.3",
     "@vitest/browser-playwright": "^4.1.10",
     "chalk": "^4.1.2",
@@ -17,6 +14,7 @@
     "nan": "^2.22.2",
     "node-addon-api": "8.6.0",
     "tap": "~0.7.1",
+    "vite": "^7.3.6",
     "vite-plugin-commonjs": "^0.10.4",
     "vite-plugin-node-polyfills": "^0.28.0",
     "vitest": "^4.1.10",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -14,7 +14,6 @@
     "nan": "^2.22.2",
     "node-addon-api": "8.6.0",
     "tap": "~0.7.1",
-    "vite": "^7.3.6",
     "vite-plugin-commonjs": "^0.10.4",
     "vite-plugin-node-polyfills": "^0.28.0",
     "vitest": "^4.1.10",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -5,6 +5,7 @@
   "description": "emnapi test",
   "main": "index.js",
   "devDependencies": {
+    "@emnapi/runtime": "*",
     "@tybys/wasm-util": "^0.10.3",
     "@vitest/browser-playwright": "^4.1.10",
     "chalk": "^4.1.2",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -5,9 +5,9 @@
   "description": "emnapi test",
   "main": "index.js",
   "devDependencies": {
-    "@emnapi/core": "*",
-    "@emnapi/node-binding": "*",
-    "@emnapi/runtime": "*",
+    "@emnapi/core": "2.0.0-alpha.3",
+    "@emnapi/node-binding": "1.4.0",
+    "@emnapi/runtime": "2.0.0-alpha.3",
     "@tybys/wasm-util": "^0.10.3",
     "@vitest/browser-playwright": "^4.1.10",
     "chalk": "^4.1.2",

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -13,6 +13,7 @@
     "memfs-browser": "^3.5.10302",
     "nan": "^2.22.2",
     "node-addon-api": "8.6.0",
+    "playwright": "^1.61.0",
     "tap": "~0.7.1",
     "vite-plugin-commonjs": "^0.10.4",
     "vite-plugin-node-polyfills": "^0.28.0",


### PR DESCRIPTION
## Summary

This branch optimizes several hot paths in `@emnapi/runtime` and the emnapi Emscripten library, and adds a Node benchmark suite (`packages/bench/bench.mjs`) to measure them.

## Changes

**Queue and allocator operations**
- Replace `Array.prototype.shift()` with a head-pointer plus periodic compaction in:
  - the async work pending queue and id-reuse list (`async-work.ts`)
  - the pending finalizer queue (`env.ts`)
  - the id free list (`Store.ts`)
  - the persistent handle recycle list (`Persistent.ts`)
- `CleanupQueue`: replace the O(n) `filter()` duplicate scan with a `WeakMap<Env, Map<fn, Set<arg>>>` index that is built once the queue exceeds a threshold; drain in LIFO order without sorting.
- Build the backing array in the default store constructor with `push()` instead of `Array(initialCapacity)` to avoid a holey array.

**Wasm memory view caching**
- Cache the `Uint8Array`/`Uint16Array` views of wasm memory and rebuild them only when the underlying buffer or its `byteLength` changes, instead of allocating a new view on every use (`memory.ts`, `string.ts`, `emnapi.ts`, `create.ts`).
- Collapse `WeakMap.has()` + `get()` into a single `get()`.

**Callback plumbing**
- Use `arguments` instead of rest-parameter spread in generated callback wrappers (`Context.ts`, `FunctionTemplate.ts`).
- Remove a redundant bounds check in `HandleScope.escapeHandle`.

**ObjectTemplate accessors**
- Create getter/setter wrappers once per template and reuse them across instances, instead of creating a new bound wrapper per instance; resolve the holder via a template-level `WeakSet` walk.

**Number and BigInt conversion**
- `napi_get_value_int32` / `napi_get_value_uint32`: use `jsValue | 0` / `jsValue >>> 0` instead of allocating a temporary `Int32Array` / `Uint32Array`.
- `napi_get_value_bigint_int64` / `napi_get_value_bigint_uint64`: use `BigInt.asIntN` / `BigInt.asUintN`.
- `napi_create_bigint_words`: accumulate with left shifts instead of repeatedly adding `word << (64 * i)`.
- `napi_get_value_bigint_words`: drop the intermediate word array.

**Latin-1 string copy**
- Bound the copy loop by the actual string length (`min(len, buf_size - 1)`) instead of `buf_size - 1`. This also fixes the reported copy count, which previously returned `buf_size - 1` when the buffer was larger than the string.

## Benchmark results

Both branches were built with the same emsdk and Node v24.18.0 in Release mode and measured with the same harness. The full suite (maxTime 1 s, minSamples 30) was run twice per branch; the averages are below. Small deltas were re-checked with interleaved A/B runs and fell within machine noise.

| Case | Baseline (ops/s) | This branch (ops/s) | Change |
|---|---|---|---|
| cleanupQueue1024 | 319,670 | 8,796,971 | +2652% |
| finalizerQueueDrain1024 | 31,054,784 | 311,271,410 | +902% |
| getLatin1Oversized | 868,964 | 7,444,839 | +757% |
| cleanupQueue16 | 18,374,646 | 48,013,316 | +161% |
| cleanupQueue1 | 16,941,587 | 39,530,527 | +133% |
| objectTemplateAccessor64 | 10,449,827 | 20,569,995 | +97% |
| createBigIntWords4 | 15,528,674 | 22,609,844 | +46% |
| convertInteger (C) | 5,649,696 | 8,209,804 | +45% |
| convertInteger (C++) | 4,807,792 | 6,707,406 | +40% |
| convertBigIntUint64 | 4,493,124 | 6,210,136 | +38% |
| convertBigIntInt64 | 4,724,104 | 6,277,377 | +33% |
| getBigIntWords4 | 11,116,037 | 13,147,390 | +18% |
| convertString (C++/C) | 3,124,086 / 3,527,200 | 3,372,935 / 3,718,899 | +8.0% / +5.4% |
| objectGet (C++/C) | 4,183,678 / 4,687,240 | 4,393,678 / 4,843,477 | +5.0% / +3.3% |
| referenceChurn64 (C++/C) | 2,995,947 / 3,016,433 | 3,122,044 / 3,122,451 | +4.2% / +3.5% |
| handleChurn64 (C/C++) | 59,301,958 / 51,314,622 | 61,714,087 / 53,129,865 | +4.1% / +3.5% |

Overall geometric mean: **+20.5%** across emnapi C/C++ cases and **+285%** across the runtime cases. The unchanged embind control stayed flat (−1.4%), confirming the gains are not machine drift.

Notes:

- `getLatin1Oversized` (+757%) includes the Latin-1 copy loop fix above, so part of the gain comes from doing less (previously incorrect) work rather than only faster work.
